### PR TITLE
feat: OpenCode Go presets + recover orphan managed block

### DIFF
--- a/src-tauri/src/codex.rs
+++ b/src-tauri/src/codex.rs
@@ -54,6 +54,12 @@ pub struct CodexStatus {
     pub codex_home: String,
     pub config_exists: bool,
     pub managed_block_present: bool,
+    /// A `# BEGIN` marker without a matching `# END`: an external rewrite of
+    /// config.toml (e.g. the Codex desktop app re-serializing the file)
+    /// dropped the trailing comment. `strip_managed_block` recovers from
+    /// this by ownership, but the UI should surface it instead of showing a
+    /// dead Apply/Remove button.
+    pub managed_block_orphaned: bool,
     pub native_catalog_present: bool,
     pub merged_catalog_present: bool,
     pub merged_model_count: usize,
@@ -96,6 +102,7 @@ pub fn status(config: &AppConfig) -> CodexStatus {
         codex_home: home.display().to_string(),
         config_exists: cfg_path.exists(),
         managed_block_present: raw.contains(BEGIN_MARK),
+        managed_block_orphaned: raw.contains(BEGIN_MARK) && !raw.contains(END_MARK),
         native_catalog_present: native_catalog_path().exists(),
         merged_catalog_present: merged_catalog_path().exists(),
         merged_model_count: count,
@@ -1531,11 +1538,16 @@ fn detect_newline(raw: &str) -> &'static str {
     }
 }
 
-/// Remove the managed block. A BEGIN marker without a matching END is the
-/// signature of a previously interrupted write; in that case we refuse to
-/// touch the file with an explicit error instead of silently deleting
-/// everything after the marker. Line endings of the surviving content are
+/// Remove the managed block. Line endings of the surviving content are
 /// preserved.
+///
+/// A BEGIN marker without a matching END is what an external rewrite of
+/// config.toml leaves behind (the Codex desktop app re-serializes the file
+/// and drops the trailing comment). Bricking apply/remove over that would
+/// strand the user, so we recover by ownership: drop the orphan marker and
+/// strip exactly what we can prove is ours — the owned root keys and the
+/// `[model_providers.loomrouter]` table (see `recover_orphan_managed_block`).
+/// Content that is not ours is never touched.
 fn strip_managed_block(raw: &str) -> anyhow::Result<String> {
     let nl = detect_newline(raw);
     let mut out = String::new();
@@ -1560,14 +1572,58 @@ fn strip_managed_block(raw: &str) -> anyhow::Result<String> {
         }
     }
     if saw_begin && !saw_end {
+        return recover_orphan_managed_block(raw, nl);
+    }
+    Ok(out)
+}
+
+/// Whether a `config.toml` line is the `[model_providers.loomrouter]` table
+/// header (or one of its sub-tables).
+fn is_loomrouter_table(line: &str) -> bool {
+    let t = line.trim();
+    let Some(inner) = t.strip_prefix('[').and_then(|s| s.strip_suffix(']')) else {
+        return false;
+    };
+    let inner = inner.trim();
+    inner == "model_providers.loomrouter" || inner.starts_with("model_providers.loomrouter.")
+}
+
+/// Whether a `config.toml` carries content LoomRouter demonstrably owns: a
+/// `loomrouter` provider table, or a root `model_provider` pointing at it.
+fn has_loomrouter_content(raw: &str) -> bool {
+    raw.lines().any(|l| {
+        is_loomrouter_table(l)
+            || (is_root_assignment(l, "model_provider")
+                && l.split_once('=')
+                    .is_some_and(|(_, v)| v.contains("loomrouter")))
+    })
+}
+
+/// Recover from a `# BEGIN` marker with no matching `# END`.
+///
+/// The orphan is the signature of an external rewrite (e.g. the Codex
+/// desktop app round-tripping config.toml and dropping the trailing
+/// comment), not necessarily an interrupted write. Removing the marker and
+/// then stripping by ownership is safe: only the owned root keys and the
+/// `[model_providers.loomrouter]` table are deleted, and anything that is
+/// not ours — marketplaces, plugins, hooks, mcp_servers — survives intact.
+/// When nothing of ours is present the marker is genuinely ambiguous, and
+/// we keep the defensive refusal instead of guessing.
+fn recover_orphan_managed_block(raw: &str, nl: &str) -> anyhow::Result<String> {
+    let without_marker: String = raw
+        .lines()
+        .filter(|l| l.trim() != BEGIN_MARK)
+        .collect::<Vec<_>>()
+        .join(nl);
+    if !has_loomrouter_content(&without_marker) {
         anyhow::bail!(
             "config.toml has a loom-router BEGIN marker without a matching END \
-             (likely left over from an interrupted write); refusing to modify \
+             and no loom-router-managed content to remove; refusing to modify \
              the file. Restore it from config.toml.bak or remove the marker \
              manually."
         );
     }
-    Ok(out)
+    Ok(strip_legacy_install(&without_marker))
 }
 
 /// Root keys the integration owns. The managed block re-declares all of
@@ -1588,20 +1644,7 @@ const OWNED_ROOT_KEYS: [&str; 3] = ["model_provider", "openai_base_url", "model_
 /// `model_provider` pointing at it. A user's own `model_provider` naming
 /// any other provider, and profile-level keys, are left untouched.
 fn strip_legacy_install(stripped: &str) -> String {
-    let is_loomrouter_table = |line: &str| {
-        let t = line.trim();
-        let Some(inner) = t.strip_prefix('[').and_then(|s| s.strip_suffix(']')) else {
-            return false;
-        };
-        let inner = inner.trim();
-        inner == "model_providers.loomrouter" || inner.starts_with("model_providers.loomrouter.")
-    };
-    let is_legacy = stripped.lines().any(|l| {
-        is_loomrouter_table(l)
-            || (is_root_assignment(l, "model_provider")
-                && l.split_once('=').is_some_and(|(_, v)| v.contains("loomrouter")))
-    });
-    if !is_legacy {
+    if !has_loomrouter_content(stripped) {
         return stripped.to_string();
     }
 
@@ -1614,12 +1657,11 @@ fn strip_legacy_install(stripped: &str) -> String {
         if t.starts_with('[') {
             seen_table = true;
             in_legacy_table = is_loomrouter_table(line);
-            if in_legacy_table {
-                continue;
-            }
-        } else if in_legacy_table {
+        }
+        if in_legacy_table {
             continue;
-        } else if !seen_table && OWNED_ROOT_KEYS.iter().any(|k| is_root_assignment(line, k)) {
+        }
+        if !seen_table && OWNED_ROOT_KEYS.iter().any(|k| is_root_assignment(line, k)) {
             continue;
         }
         out.push(line);
@@ -1635,6 +1677,15 @@ fn strip_legacy_install(stripped: &str) -> String {
 mod tests {
     use super::*;
     use crate::config::{Provider, ProviderModel, ProviderProtocol};
+
+    /// Serializes the tests that mutate `CODEX_HOME` (and `CODEX_BIN`): cargo
+    /// runs tests in parallel threads, and env vars are process-global, so
+    /// two such tests writing different temp dirs would clobber each other.
+    fn codex_home_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
     use std::collections::BTreeMap;
 
     #[test]
@@ -1648,10 +1699,91 @@ mod tests {
 
     #[test]
     fn strip_refuses_begin_without_end() {
-        // Signature of an interrupted write: everything after BEGIN would be
-        // silently deleted by the old implementation. Now it is an error.
+        // An orphan BEGIN with *no* loom-router content is genuinely
+        // ambiguous (a stray marker with nothing of ours behind it); the
+        // defensive refusal stays so we never guess and delete user data.
         let raw = "model = \"gpt-5\"\n# BEGIN loom-router-managed\nopenai_base_url = \"x\"\n[profiles.work]\n";
         assert!(strip_managed_block(raw).is_err());
+    }
+
+    #[test]
+    fn orphan_begin_is_recovered_by_ownership() {
+        // Replicates a real breakage: the Codex desktop app re-serialized
+        // config.toml and dropped the `# END` comment, leaving an orphan
+        // BEGIN with our owned root keys + provider table inside it. The
+        // strip must remove exactly what is ours and keep the rest.
+        let raw = "notify = [\"turn-ended\"]\napproval_policy = \"on-request\"\n# BEGIN loom-router-managed\nmodel_provider = \"loomrouter\"\nopenai_base_url = \"http://127.0.0.1:4180/v1\"\nmodel_catalog_json = \"~/.codex/loom-router/merged-models.json\"\nmodel = \"opencode-zen-chat/deepseek-v4-flash\"\nmodel_reasoning_effort = \"medium\"\n\n[model_providers.loomrouter]\nname = \"OpenAI\"\nbase_url = \"http://127.0.0.1:4180/v1\"\nwire_api = \"responses\"\nhttp_headers = { \"x-loomrouter-token\" = \"t\", \"Authorization\" = \"Bearer t\" }\n\n[marketplaces.openai-bundled]\nlast_updated = \"2026-08-06T13:58:21Z\"\n\n[hooks.state]\n";
+        let out = strip_managed_block(raw).unwrap();
+        // Our markers and owned root keys are gone.
+        assert!(!out.contains(BEGIN_MARK));
+        assert!(!out.contains("model_provider"));
+        assert!(!out.contains("openai_base_url"));
+        assert!(!out.contains("model_catalog_json"));
+        assert!(!out.contains("[model_providers.loomrouter]"));
+        assert!(!out.contains("x-loomrouter-token"));
+        // The user's own settings survive untouched.
+        assert!(out.contains("notify = [\"turn-ended\"]"));
+        assert!(out.contains("approval_policy = \"on-request\""));
+        assert!(out.contains("[marketplaces.openai-bundled]"));
+        assert!(out.contains("last_updated = \"2026-08-06T13:58:21Z\""));
+        assert!(out.contains("[hooks.state]"));
+        // And the result parses cleanly (no duplicate keys left behind).
+        let parsed: toml::Value = toml::from_str(&out).unwrap();
+        assert_eq!(
+            parsed.get("approval_policy").and_then(toml::Value::as_str),
+            Some("on-request")
+        );
+    }
+
+    #[test]
+    fn orphan_recovery_preserves_model_key_restore_path() {
+        // The orphaned region may also swallow root `model`/effort keys the
+        // desktop app re-emitted; `remove()` reconciles the root `model`
+        // afterwards, so recovery must leave the stripped text parseable.
+        let raw = "# BEGIN loom-router-managed\nmodel_provider = \"loomrouter\"\nopenai_base_url = \"x\"\nmodel_catalog_json = \"y\"\nmodel = \"deepseek/deepseek-chat\"\nmodel_reasoning_effort = \"medium\"\n\n[model_providers.loomrouter]\nwire_api = \"responses\"\n\n[profiles.work]\nmodel = \"gpt-5\"\n";
+        let out = strip_managed_block(raw).unwrap();
+        assert!(!out.contains(BEGIN_MARK));
+        assert!(!out.contains("model_provider"));
+        assert!(!out.contains("[model_providers.loomrouter]"));
+        assert!(out.contains("[profiles.work]"));
+        assert!(out.contains("model = \"gpt-5\""));
+    }
+
+    #[test]
+    fn status_flags_orphaned_managed_block() {
+        let _guard = codex_home_guard();
+        let tmp = std::env::temp_dir().join(format!("loom-codex-status-{}", std::process::id()));
+        std::env::set_var("CODEX_HOME", &tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        // Orphan: BEGIN without END (the external-rewrite signature).
+        std::fs::write(
+            tmp.join("config.toml"),
+            "# BEGIN loom-router-managed\nmodel_provider = \"loomrouter\"\n",
+        )
+        .unwrap();
+        let status = status(&demo_config());
+        assert!(status.managed_block_present);
+        assert!(status.managed_block_orphaned);
+        std::env::remove_var("CODEX_HOME");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn status_does_not_flag_complete_managed_block() {
+        let _guard = codex_home_guard();
+        let tmp = std::env::temp_dir().join(format!("loom-codex-status-ok-{}", std::process::id()));
+        std::env::set_var("CODEX_HOME", &tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        std::fs::write(
+            tmp.join("config.toml"),
+            "# BEGIN loom-router-managed\nmodel_provider = \"loomrouter\"\n# END loom-router-managed\n",
+        )
+        .unwrap();
+        let status = status(&demo_config());
+        assert!(status.managed_block_present);
+        assert!(!status.managed_block_orphaned);
+        std::env::remove_var("CODEX_HOME");
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]
@@ -1972,6 +2104,7 @@ mod tests {
         // Regression test for the macOS report: applying with zero enabled
         // models wrote an empty merged-models.json, and Codex then refused
         // to load config.toml entirely ("must contain at least one model").
+        let _guard = codex_home_guard();
         let tmp = std::env::temp_dir().join(format!("loom-codex-test-{}", std::process::id()));
         std::env::set_var("CODEX_HOME", &tmp);
         // A binary that never runs, so the native capture fails gracefully

--- a/src-tauri/src/providers.rs
+++ b/src-tauri/src/providers.rs
@@ -152,6 +152,49 @@ pub const PRESETS: &[Preset] = &[
         default_models: &["gpt-5.5", "gpt-5.4-mini", "gpt-5.4-nano", "grok-4.5"],
         user_agent: None,
     },
+    // OpenCode Go (low-cost subscription) is the same gateway under the
+    // /go/ path: https://opencode.ai/zen/go/v1. Same dialect split as Zen —
+    // MiniMax/Qwen are served via Anthropic Messages, GPT-5.6 Luna via
+    // Responses, the rest via Chat Completions.
+    Preset {
+        id: "opencode-go-chat",
+        name: "OpenCode Go (Kimi/GLM/DeepSeek/MiMo/Hy3)",
+        protocol: ProviderProtocol::OpenAI,
+        base_url: "https://opencode.ai/zen/go/v1",
+        default_models: &[
+            "kimi-k3",
+            "kimi-k2.7-code",
+            "glm-5.2",
+            "deepseek-v4-pro",
+            "deepseek-v4-flash",
+            "mimo-v2.5-pro",
+            "hy3",
+        ],
+        user_agent: None,
+    },
+    Preset {
+        id: "opencode-go-claude",
+        name: "OpenCode Go (MiniMax/Qwen)",
+        protocol: ProviderProtocol::Anthropic,
+        base_url: "https://opencode.ai/zen/go/v1",
+        default_models: &[
+            "minimax-m3",
+            "minimax-m2.7",
+            "qwen3.8-max",
+            "qwen3.7-max",
+            "qwen3.7-plus",
+            "qwen3.6-plus",
+        ],
+        user_agent: None,
+    },
+    Preset {
+        id: "opencode-go-responses",
+        name: "OpenCode Go (GPT-5.6 Luna)",
+        protocol: ProviderProtocol::Responses,
+        base_url: "https://opencode.ai/zen/go/v1",
+        default_models: &["gpt-5.6-luna"],
+        user_agent: None,
+    },
 ];
 
 impl Provider {

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -22,7 +22,11 @@ vi.mock('@/lib/api', () => ({
     contextWindows: () => Promise.resolve({}),
     statsSummary: () => Promise.resolve(null),
     codexStatus: () =>
-      Promise.resolve({ managed_block_present: false, codex_cli_available: true }),
+      Promise.resolve({
+        managed_block_present: false,
+        managed_block_orphaned: false,
+        codex_cli_available: true,
+      }),
     multiAgentStatus: () => Promise.resolve(false),
     completeOnboarding: () => Promise.resolve(),
   },

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -114,6 +114,7 @@ const en = {
     cliMissingHint: 'Not found. LoomRouter checks your PATH, your login shell and the usual install locations — if Codex lives somewhere else, set CODEX_BIN to its full path and reopen the app.',
     nativeCatalog: 'Native catalog captured',
     restartHint: 'Fully quit and reopen Codex after applying — Codex only loads the catalog at startup.',
+    orphanedHint: 'Codex config was rewritten externally and lost its managed block markers. Apply or remove the integration to repair it — your own settings are preserved.',
     autoApplyHint: 'Auto-apply is on: provider and model changes are synced to Codex automatically. Just restart Codex to pick them up.',
     activeModelTitle: 'Active model',
     activeModelDescription: 'The model Codex starts new sessions with. Also switchable from the menu bar.',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -112,6 +112,7 @@ const es: DeepPartial<Strings> = {
     cliMissingHint: 'No encontrada. LoomRouter busca en tu PATH, en tu shell de inicio y en las ubicaciones habituales — si Codex está en otro sitio, define CODEX_BIN con la ruta completa y reabre la app.',
     nativeCatalog: 'Catálogo nativo capturado',
     restartHint: 'Cierra por completo y vuelve a abrir Codex después de aplicar: Codex solo carga el catálogo al iniciar.',
+    orphanedHint: 'La configuración de Codex se reescribió externamente y perdió los marcadores del bloque gestionado. Aplica o quita la integración para repararlo: tus ajustes se conservan.',
     autoApplyHint: 'La aplicación automática está activada: los cambios de proveedores y modelos se sincronizan con Codex automáticamente. Solo reinicia Codex para aplicarlos.',
     sideCallTitle: 'Llamadas en segundo plano',
     sideCallDescription: 'Modelo usado para el trabajo en segundo plano de Codex (títulos de chats, compactación, etc.). Desactivado mantiene el valor predeterminado de Codex.',

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -111,6 +111,7 @@ const pt: DeepPartial<Strings> = {
     cliMissingHint: 'Não encontrada. O LoomRouter procura no seu PATH, no seu shell de login e nos locais de instalação comuns — se o Codex estiver em outro lugar, defina CODEX_BIN com o caminho completo e reabra o app.',
     nativeCatalog: 'Catálogo nativo capturado',
     restartHint: 'Feche completamente e reabra o Codex após aplicar — o Codex só carrega o catálogo na inicialização.',
+    orphanedHint: 'O config do Codex foi reescrito externamente e perdeu os marcadores do bloco gerenciado. Aplique ou remova a integração para reparar — suas configurações são preservadas.',
     autoApplyHint: 'Aplicação automática ativada: alterações de provedores e modelos são sincronizadas com o Codex automaticamente. Basta reiniciar o Codex para aplicá-las.',
     sideCallTitle: 'Chamadas em segundo plano',
     sideCallDescription: 'Modelo usado para o trabalho em segundo plano do Codex (títulos de conversas, compactação etc.). Desligado mantém o padrão do Codex.',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -114,6 +114,7 @@ const zh: DeepPartial<Strings> = {
     cliMissingHint: '未找到。LoomRouter 会检查你的 PATH、登录 shell 以及常见安装位置 —— 如果 Codex 在别处，请将 CODEX_BIN 设为完整路径后重新打开应用。',
     nativeCatalog: '已捕获原生目录',
     restartHint: '应用后请完全退出并重新打开 Codex——Codex 只在启动时加载目录。',
+    orphanedHint: 'Codex 配置被外部重写，丢失了受管块的标记。应用或移除集成即可修复——你自己的设置会被保留。',
     autoApplyHint: '自动应用已开启：提供商和模型的更改会自动同步到 Codex。只需重启 Codex 即可生效。',
     sideCallTitle: '后台调用',
     sideCallDescription: '用于 Codex 后台工作的模型（会话标题、压缩等）。关闭则保持 Codex 默认。',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -210,6 +210,7 @@ function mock<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
         codex_home: '~/.codex',
         config_exists: true,
         managed_block_present: mockState.codexApplied,
+        managed_block_orphaned: false,
         native_catalog_present: mockState.codexApplied,
         merged_catalog_present: mockState.codexApplied,
         merged_model_count: mockState.codexApplied ? 1 : 0,

--- a/src/pages/Codex.test.tsx
+++ b/src/pages/Codex.test.tsx
@@ -5,9 +5,10 @@
 
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 let multiAgent = false
+let orphaned = false
 const setMultiAgent = vi.fn((next: boolean) => {
   multiAgent = next
   return Promise.resolve(next)
@@ -23,6 +24,7 @@ vi.mock('@/lib/api', () => ({
         codex_home: '~/.codex',
         config_exists: true,
         managed_block_present: true,
+        managed_block_orphaned: orphaned,
         native_catalog_present: true,
         merged_catalog_present: true,
         merged_model_count: 3,
@@ -53,6 +55,10 @@ const multiAgentSwitch = async () => {
 }
 
 describe('multi-agent control', () => {
+  beforeEach(() => {
+    orphaned = false
+  })
+
   it('is reachable and turns off again once on', async () => {
     multiAgent = true
     const user = userEvent.setup()
@@ -91,5 +97,13 @@ describe('multi-agent control', () => {
     const toggle = await multiAgentSwitch()
     await user.click(toggle)
     await waitFor(() => expect(toggle).not.toBeChecked())
+  })
+})
+
+describe('orphaned managed block', () => {
+  it('warns when the config lost its markers to an external rewrite', async () => {
+    orphaned = true
+    render(<CodexPage />)
+    expect(await screen.findByText(/rewritten externally/i)).toBeInTheDocument()
   })
 })

--- a/src/pages/Codex.tsx
+++ b/src/pages/Codex.tsx
@@ -26,6 +26,7 @@ export default function CodexPage() {
   const [status, setStatus] = useState<CodexStatus | null>(null)
   const [config, setConfig] = useState<AppConfig | null>(null)
   const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const reload = () => {
     api.getConfig().then(setConfig)
@@ -39,9 +40,12 @@ export default function CodexPage() {
 
   const apply = async () => {
     setBusy(true)
+    setError(null)
     try {
       await api.codexApply()
       await reload()
+    } catch (e) {
+      setError(String(e instanceof Error ? e.message : e))
     } finally {
       setBusy(false)
     }
@@ -49,9 +53,12 @@ export default function CodexPage() {
 
   const remove = async () => {
     setBusy(true)
+    setError(null)
     try {
       await api.codexRemove()
       await reload()
+    } catch (e) {
+      setError(String(e instanceof Error ? e.message : e))
     } finally {
       setBusy(false)
     }
@@ -96,6 +103,10 @@ export default function CodexPage() {
               </Button>
             )}
           </div>
+          {status?.managed_block_orphaned && (
+            <p className="text-xs text-amber-600 dark:text-amber-500">{s.codex.orphanedHint}</p>
+          )}
+          {error && <p className="text-xs text-red-600 dark:text-red-500">{error}</p>}
           <p className="text-xs text-muted-foreground">{s.codex.restartHint}</p>
           {status?.integration_enabled && (
             <p className="text-xs text-green-600 dark:text-green-500">{s.codex.autoApplyHint}</p>

--- a/src/pages/Onboarding.test.tsx
+++ b/src/pages/Onboarding.test.tsx
@@ -35,6 +35,7 @@ vi.mock('@/lib/api', () => ({
         codex_home: '~/.codex',
         config_exists: true,
         managed_block_present: managedBlock,
+        managed_block_orphaned: false,
         native_catalog_present: managedBlock,
         merged_catalog_present: managedBlock,
         merged_model_count: 0,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -184,4 +184,7 @@ export const PRESETS: ProviderPreset[] = [
   { id: 'opencode-zen-chat', name: 'OpenCode Zen (Kimi/GLM/DeepSeek/MiniMax)', protocol: 'openai', base_url: 'https://opencode.ai/zen/v1', defaultModels: ['kimi-k3', 'kimi-k2.7-code', 'glm-5.2', 'deepseek-v4-pro', 'deepseek-v4-flash', 'minimax-m3'] },
   { id: 'opencode-zen-claude', name: 'OpenCode Zen (Claude/Qwen)', protocol: 'anthropic', base_url: 'https://opencode.ai/zen/v1', defaultModels: ['claude-sonnet-5', 'claude-opus-5', 'claude-haiku-4-5', 'qwen3.7-plus'] },
   { id: 'opencode-zen-responses', name: 'OpenCode Zen (GPT/Grok)', protocol: 'responses', base_url: 'https://opencode.ai/zen/v1', defaultModels: ['gpt-5.5', 'gpt-5.4-mini', 'gpt-5.4-nano', 'grok-4.5'] },
+  { id: 'opencode-go-chat', name: 'OpenCode Go (Kimi/GLM/DeepSeek/MiMo/Hy3)', protocol: 'openai', base_url: 'https://opencode.ai/zen/go/v1', defaultModels: ['kimi-k3', 'kimi-k2.7-code', 'glm-5.2', 'deepseek-v4-pro', 'deepseek-v4-flash', 'mimo-v2.5-pro', 'hy3'] },
+  { id: 'opencode-go-claude', name: 'OpenCode Go (MiniMax/Qwen)', protocol: 'anthropic', base_url: 'https://opencode.ai/zen/go/v1', defaultModels: ['minimax-m3', 'minimax-m2.7', 'qwen3.8-max', 'qwen3.7-max', 'qwen3.7-plus', 'qwen3.6-plus'] },
+  { id: 'opencode-go-responses', name: 'OpenCode Go (GPT-5.6 Luna)', protocol: 'responses', base_url: 'https://opencode.ai/zen/go/v1', defaultModels: ['gpt-5.6-luna'] },
 ]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,6 +86,7 @@ export interface CodexStatus {
   codex_home: string
   config_exists: boolean
   managed_block_present: boolean
+  managed_block_orphaned: boolean
   native_catalog_present: boolean
   merged_catalog_present: boolean
   merged_model_count: number


### PR DESCRIPTION
## O que mudou

Dois fixes que se conectam: usuários com assinatura **OpenCode Go** batiam 401 (`Insufficient balance`) no provider **Zen**, e o estado órfão do `config.toml` travava a remoção da integração.

### 1. Presets OpenCode Go (`feat(providers)`)
A assinatura Go é o mesmo gateway da opencode.ai sob `/zen/go/v1` — a key Go 401a no endpoint Zen. Adicionados 3 presets espelhando a divisão de dialetos do Zen:
- `opencode-go-chat` (OpenAI): kimi-k3, kimi-k2.7-code, glm-5.2, deepseek-v4-pro/flash, mimo-v2.5-pro, hy3
- `opencode-go-claude` (Anthropic): minimax-m3/m2.7, qwen3.8/3.7-max/3.7-plus/3.6-plus
- `opencode-go-responses` (Responses): gpt-5.6-luna

### 2. Recovery de bloco órfão (`fix(codex)`)
O app desktop da Codex também escreve em `~/.codex/config.toml`; o round-trip TOML dele pode descartar o `# END loom-router-managed`, deixando um BEGIN órfão. O `strip_managed_block` recusava tocar o arquivo nesse estado → apply e remove falhavam em silêncio (uma porta só de ida).

- Recovery por ownership: remove o marcador órfão + chaves/tabela que provadamente são nossas, preservando marketplaces/plugins/hooks
- `CodexStatus.managed_block_orphaned` para a UI detectar
- Página Codex avisa sobre reescrita externa; apply/remove exibem erro em vez de falhar calados

## Verificação
- `cargo test`: 85 passando
- `cargo clippy --all-targets -- -D warnings` e `cargo fmt --check`: limpos (corrigi um warning pré-existente que bloquearia o release)
- `bun run build`, `tsc`, `eslint`: limpos
- `vitest`: 45 passando (requer `NODE_OPTIONS=--no-experimental-webstorage` no Node 26 local — pré-existente)