### PR TITLE
ci: pin every action to a commit SHA, and drop the dead advisory link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,28 @@ jobs:
           toolchain: stable
           components: clippy, rustfmt
 
+      # The slowest step in this job, and the most variable: 27s on a good day
+      # and 103s on a bad one, every run, uncached.
+      #
+      # `libappindicator3-dev` was the pre-Ayatana package. Tauri v2 documents
+      # `libayatana-appindicator3-dev` for Debian/Ubuntu, and this crate builds
+      # with `features = ["tray-icon"]`, so the tray is real and the dependency
+      # is not optional — it was simply the wrong one, working by accident.
+      #
+      # `patchelf` only matters when bundling an AppImage. Neither workflow
+      # bundles on Linux: release.yml builds installers on windows-latest and
+      # the two macOS runners, and its Linux job runs the same fmt/clippy/test
+      # as this one.
+      #
+      # `--no-install-recommends` keeps apt from pulling the suggested extras
+      # around each of these, which is most of the download volume.
       - name: Install Tauri system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -49,11 +49,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to the head of this action's `stable` branch. The branch name
+        # was the toolchain selector, so once it is replaced by a SHA the
+        # toolchain has to be stated explicitly or the intent is unreadable.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           components: clippy, rustfmt
 
       - name: Install Tauri system dependencies
@@ -62,7 +66,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,28 @@ name: CI
 # tags. Between v0.2.0 and the commits that followed it, main accumulated a
 # frontend type error that broke `bun run build` and a formatting drift that
 # broke `cargo fmt --check` — neither was caught, because nothing ran until
-# somebody cut a release. This runs the same checks on every push and PR, so
-# a broken main is visible the moment it happens instead of at release time.
+# somebody cut a release. This runs the same checks before a change reaches
+# main and again once it lands, so a broken main is visible the moment it
+# happens instead of at release time.
 
 on:
+  # `pull_request` covers a change before it merges; `push` on main covers it
+  # after. Anything wider double-fires: `branches: ["**"]` meant that pushing
+  # a branch and opening a pull request for it queued two runs of every job,
+  # both publishing the same check names the branch ruleset requires, so the
+  # merge waited on four checks instead of two. The concurrency group below
+  # cannot collapse them either — github.ref is refs/heads/<branch> for the
+  # push and refs/pull/<n>/merge for the pull request, so they land in
+  # different groups and neither cancels the other.
+  #
+  # A branch with no pull request open now gets no run. That is the case
+  # where the result had nobody waiting on it.
+  #
+  # A `branches` filter also excludes tag pushes on its own, so the previous
+  # `tags-ignore: ["v*"]` is no longer needed to keep release.yml the only
+  # thing gating tags.
   push:
-    branches: ["**"]
-    tags-ignore: ["v*"] # release.yml already gates tags
+    branches: [main]
   pull_request:
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Verify tag version
         shell: bash
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -64,8 +64,12 @@ jobs:
         run: bun run build
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to the head of this action's `stable` branch. The branch name
+        # was the toolchain selector, so once it is replaced by a SHA the
+        # toolchain has to be stated explicitly or the intent is unreadable.
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           components: clippy, rustfmt
 
       - name: Install Tauri system dependencies
@@ -74,7 +78,7 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
 
@@ -115,10 +119,10 @@ jobs:
             updater_label: macOS Intel app bundle (updater)
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -126,10 +130,12 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri
 
@@ -157,7 +163,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Build and publish release assets
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Signs the updater artifacts (latest.json + .sig) so installed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,10 +72,16 @@ jobs:
           toolchain: stable
           components: clippy, rustfmt
 
+      # Kept identical to ci.yml — this job is the same gate, and the two
+      # drifting apart is how a release passes checks that main never ran.
+      # See ci.yml for why the Ayatana package and why patchelf is gone.
       - name: Install Tauri system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,10 +23,6 @@ ignored.
 
 You'll be credited in the release notes unless you'd rather not be.
 
-If you'd genuinely rather not say it in public, GitHub's
-[private advisory form](https://github.com/imateusdev/loom-router/security/advisories/new)
-is still there and still read. It's just not required.
-
 ## Supported versions
 
 Only the latest release. Fixes ship forward in a new version and reach users


### PR DESCRIPTION
## What changed, and why

Two changes that both became necessary the moment the repository went public.

**Every action is now pinned to a full-length commit SHA.** "Require actions to be pinned to a full-length commit SHA" was enabled in the repository settings, and that setting fails any workflow run referencing an action by tag. Both workflows had to be converted together: the branch ruleset requires both CI jobs to pass before anything merges, so a change that left either workflow failing could not have landed.

The underlying reason the setting is worth having: a tag is a mutable pointer. `actions/checkout@v6` resolves to whatever commit its owner has that tag on when the job starts. The exposure is not uniform across the two workflows — `release.yml` is the one that puts `TAURI_SIGNING_PRIVATE_KEY` in the environment, so an action swapped underneath it would read the key that signs the updater artifacts every installed copy already trusts.

| action | pinned to | was |
| --- | --- | --- |
| `actions/checkout` | `d23441a…` | `@v6` (v6.1.0) |
| `oven-sh/setup-bun` | `0c5077e…` | `@v2` (v2.2.0) |
| `dtolnay/rust-toolchain` | `4360b52…` | `@stable` |
| `Swatinem/rust-cache` | `6323deb…` | `@v2` (v2.9.2) |
| `tauri-apps/tauri-action` | `84b9d35…` | `@v0` (v0.6.2) |

`dtolnay/rust-toolchain` needed more than a SHA. Its `stable` ref is a branch rather than a tag, and the branch name was doubling as the toolchain selector — the `action.yml` on that branch defaults `toolchain` to `stable`. Pinning preserves the behaviour but destroys the intent for anyone reading the file, so `toolchain: stable` is now written out.

The `# vX.Y.Z` comments are load-bearing. Dependabot updates a pinned SHA and rewrites the trailing comment when it sits on the same line, which is what stops pinning from becoming permanently frozen actions.

**SECURITY.md loses its closing paragraph.** It offered GitHub's private advisory form to reporters who preferred not to post publicly, but private vulnerability reporting is disabled on this repository, so that link led to a form accepting nothing. An option that silently does not work is worse than not offering one. Public issues remain the stated channel.

## How it was verified

Both SHAs resolved through the GitHub API rather than copied by hand, dereferencing annotated tags to their commits. `action.yml` on the `stable` branch of `dtolnay/rust-toolchain` was read directly to confirm the `toolchain` default before relying on it. Both workflow files parse, and a sweep confirms no `uses:` line references a tag and no file still links the advisory form.

The real verification is this PR's own CI: it runs on the pinned workflow, under the setting that rejects tags.