### PR TITLE
fix: keep tool_calls contiguous for strict upstreams (Console Go)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 Written for the person installing the build. Internal churn is left out.
 
-## Unreleased
+## 0.2.5
 
 ### Fixed
 
-- Follow-up to 0.2.4 (not released yet — waiting on a version bump): the step that asks your shell where Codex lives now
+- **Tool calls stopped working with strict upstreams (OpenCode Go / Console Go / DeepSeek) on the Codex desktop app.** Two translation bugs combined into one failing turn: parallel tool calls were split into separate assistant messages, and Codex's macOS app interleaves a `developer` (system) message between the assistant's tool calls and their results. Either way the request reached the upstream with a `tool_calls` message that was never immediately answered, and the API rejected it with "an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'." Every engineering prompt that reached for a tool failed on a Mac while the same setup worked on Windows, because the desktop client sends that interleaved item and the CLI does not.
+
+  Parallel calls now share a single assistant message, and interleaved system messages are hoisted in front of the `tool_calls` message so the tool sequence stays contiguous. Plain chat was never affected, which is why the failure only showed up once tools were in play. (Windows is unaffected because the CLI sends neither the split calls nor the interleaved item.)
+
+- Follow-up to 0.2.4: the step that asks your shell where Codex lives now
   actually asks an interactive shell. zsh is the macOS default and only
   reads `.zshrc` for interactive shells — `.zprofile` and `.zlogin` cover
   login ones — so a login-only probe returned nothing on the setup it was

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loom-router",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2239,7 +2239,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom-router"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "loom-router"
 # Kept in lockstep with package.json and tauri.conf.json; the release
 # workflow verifies all three against the tag.
-version = "0.2.4"
+version = "0.2.5"
 description = "Weave any model into your coding agent's picker."
 authors = ["LoomRouter contributors"]
 license = "MIT"

--- a/src-tauri/src/translate.rs
+++ b/src-tauri/src/translate.rs
@@ -52,6 +52,8 @@ pub fn responses_to_chat(payload: &Value, model: &str, unified_reasoning: bool) 
         _ => return Err(anyhow!("Responses payload has no usable 'input'")),
     }
 
+    hoist_interleaved_system(&mut messages);
+
     let mut out = json!({
         "model": model,
         "messages": messages,
@@ -110,6 +112,45 @@ pub fn responses_to_chat(payload: &Value, model: &str, unified_reasoning: bool) 
         out["stream_options"] = json!({"include_usage": true});
     }
     Ok(out)
+}
+
+/// Hoist `system` messages that landed inside a tool-call block.
+///
+/// Codex (macOS desktop) interleaves `developer` items between the assistant's
+/// `function_call` items and their `function_call_output`s. Those become
+/// `system` messages sitting between an `assistant(tool_calls)` message and
+/// the `tool` messages that answer it. Strict upstreams (Console Go/DeepSeek)
+/// reject that with "an assistant message with 'tool_calls' must be followed
+/// by tool messages responding to each 'tool_call_id'"; the system message is
+/// hoisted to just before the assistant message so the tool sequence stays
+/// contiguous.
+fn hoist_interleaved_system(messages: &mut Vec<Value>) {
+    let is_tool_msg = |m: &Value| m.get("role").and_then(Value::as_str) == Some("tool");
+    let is_system = |m: &Value| m.get("role").and_then(Value::as_str) == Some("system");
+    let has_calls = |m: &Value| m.get("tool_calls").is_some();
+
+    let mut i = 0;
+    while i < messages.len() {
+        if has_calls(&messages[i]) {
+            let mut j = i + 1;
+            let mut hoisted: Vec<Value> = Vec::new();
+            while j < messages.len() {
+                if is_tool_msg(&messages[j]) {
+                    j += 1;
+                } else if is_system(&messages[j]) {
+                    hoisted.push(messages.remove(j));
+                } else {
+                    break;
+                }
+            }
+            if !hoisted.is_empty() {
+                for (k, sys) in hoisted.into_iter().enumerate() {
+                    messages.insert(i + k, sys);
+                }
+            }
+        }
+        i += 1;
+    }
 }
 
 fn convert_response_input_item(
@@ -192,20 +233,46 @@ fn convert_response_input_item(
     }
     match item_type {
         Some("function_call") => {
-            let mut msg = json!({
-                "role": "assistant",
-                "content": Value::Null,
-                "tool_calls": [{
-                    "id": item.get("call_id").or(item.get("id")).cloned().unwrap_or(Value::Null),
-                    "type": "function",
-                    "function": {
-                        "name": item.get("name").cloned().unwrap_or(Value::Null),
-                        "arguments": item.get("arguments").cloned().unwrap_or(json!("")),
-                    }
-                }]
+            let new_call = json!({
+                "id": item.get("call_id").or(item.get("id")).cloned().unwrap_or(Value::Null),
+                "type": "function",
+                "function": {
+                    "name": item.get("name").cloned().unwrap_or(Value::Null),
+                    "arguments": item.get("arguments").cloned().unwrap_or(json!("")),
+                }
             });
-            take_reasoning(&mut msg, "assistant", pending_reasoning);
-            messages.push(msg);
+            // Parallel tool calls from one assistant turn arrive as
+            // consecutive `function_call` items. Merge them into a single
+            // assistant message: strict upstreams (e.g. Console Go) 400 a
+            // request whose tool_calls message is split across consecutive
+            // assistant messages. Reasoning is left pending (opening a fresh
+            // message) rather than glued onto a call mid-batch.
+            let merged = pending_reasoning.is_empty()
+                && match messages.last_mut() {
+                    Some(Value::Object(m))
+                        if m.get("role").and_then(Value::as_str) == Some("assistant")
+                            && m.get("content").is_none_or(Value::is_null)
+                            && m.contains_key("tool_calls") =>
+                    {
+                        m.get_mut("tool_calls")
+                            .and_then(Value::as_array_mut)
+                            .map(|calls| {
+                                calls.push(new_call.clone());
+                                true
+                            })
+                            .unwrap_or(false)
+                    }
+                    _ => false,
+                };
+            if !merged {
+                let mut msg = json!({
+                    "role": "assistant",
+                    "content": Value::Null,
+                    "tool_calls": [new_call],
+                });
+                take_reasoning(&mut msg, "assistant", pending_reasoning);
+                messages.push(msg);
+            }
         }
         Some("function_call_output") => {
             messages.push(json!({
@@ -1356,6 +1423,83 @@ mod tests {
         assert_eq!(out["messages"][1]["content"], "hi");
         assert_eq!(out["tools"][0]["function"]["name"], "get_weather");
         assert_eq!(out["stream_options"]["include_usage"], true);
+    }
+
+    #[test]
+    fn parallel_function_calls_merge_into_one_assistant_message() {
+        // Codex emits parallel tool calls as consecutive `function_call`
+        // items, then the matching outputs. Splitting them into separate
+        // assistant messages breaks strict upstreams (Console Go 400s with
+        // "an assistant message with 'tool_calls' must be followed by tool
+        // messages responding to each 'tool_call_id'").
+        let payload = json!({
+            "model": "deepseek-v4-flash",
+            "input": [
+                {"role":"user","content":[{"type":"input_text","text":"do both"}]},
+                {"type":"function_call","call_id":"c1","name":"read_file","arguments":"{\"path\":\"a\"}"},
+                {"type":"function_call","call_id":"c2","name":"read_file","arguments":"{\"path\":\"b\"}"},
+                {"type":"function_call_output","call_id":"c1","output":"a"},
+                {"type":"function_call_output","call_id":"c2","output":"b"},
+                {"role":"assistant","content":[{"type":"output_text","text":"done"}]}
+            ]
+        });
+        let out = responses_to_chat(&payload, "deepseek-v4-flash", false).unwrap();
+        let msgs = out["messages"].as_array().unwrap();
+        assert_eq!(msgs[1]["role"], "assistant");
+        let calls = msgs[1]["tool_calls"].as_array().unwrap();
+        assert_eq!(
+            calls.len(),
+            2,
+            "parallel calls must share one assistant message"
+        );
+        assert_eq!(calls[0]["id"], "c1");
+        assert_eq!(calls[1]["id"], "c2");
+        assert_eq!(msgs[2]["role"], "tool");
+        assert_eq!(msgs[2]["tool_call_id"], "c1");
+        assert_eq!(msgs[3]["role"], "tool");
+        assert_eq!(msgs[3]["tool_call_id"], "c2");
+        assert_eq!(msgs[4]["role"], "assistant");
+    }
+
+    #[test]
+    fn interleaved_developer_message_does_not_break_tool_sequence() {
+        // macOS Codex injects a developer (-> system) item between the
+        // assistant's function_call items and their outputs. That must be
+        // hoisted before the tool_calls message, not left in the middle.
+        let payload = json!({
+            "model": "deepseek-v4-flash",
+            "input": [
+                {"role":"developer","content":[{"type":"input_text","text":"app-context"}]},
+                {"role":"user","content":[{"type":"input_text","text":"analise"}]},
+                {"role":"assistant","content":[{"type":"output_text","text":"vou ler"}]},
+                {"type":"function_call","call_id":"call_00_x","name":"shell","arguments":"{\"cmd\":\"ls\"}"},
+                {"type":"function_call","call_id":"call_01_y","name":"shell","arguments":"{\"cmd\":\"pwd\"}"},
+                {"role":"developer","content":[{"type":"input_text","text":"<context_guidance>hint"}]},
+                {"type":"function_call_output","call_id":"call_00_x","output":"a"},
+                {"type":"function_call_output","call_id":"call_01_y","output":"b"}
+            ]
+        });
+        let out = responses_to_chat(&payload, "deepseek-v4-flash", false).unwrap();
+        let msgs = out["messages"].as_array().unwrap();
+        let roles: Vec<&str> = msgs.iter().map(|m| m["role"].as_str().unwrap()).collect();
+        // The hoisted system must sit right before the tool_calls message.
+        assert_eq!(
+            roles,
+            [
+                "system",
+                "user",
+                "assistant",
+                "system",
+                "assistant",
+                "tool",
+                "tool"
+            ]
+        );
+        let tc = &msgs[4];
+        assert_eq!(tc["role"], "assistant");
+        assert_eq!(tc["tool_calls"].as_array().unwrap().len(), 2);
+        assert_eq!(msgs[5]["tool_call_id"], "call_00_x");
+        assert_eq!(msgs[6]["tool_call_id"], "call_01_y");
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoomRouter",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "dev.loomrouter.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-tauri/tests/e2e.rs
+++ b/src-tauri/tests/e2e.rs
@@ -267,6 +267,165 @@ async fn responses_websocket_end_to_end() {
     ws.close(None).await.unwrap();
 }
 
+/// DeepSeek-style upstream: reasoning_content then TWO parallel tool calls.
+const TOOL_SSE: &str = concat!(
+    "data: {\"id\":\"c1\",\"choices\":[{\"delta\":{\"reasoning_content\":\"need to look\"},\"finish_reason\":null}]}\n\n",
+    "data: {\"id\":\"c1\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"shell\",\"arguments\":\"\"}},{\"index\":1,\"id\":\"call_2\",\"type\":\"function\",\"function\":{\"name\":\"shell\",\"arguments\":\"\"}}]},\"finish_reason\":null}]}\n\n",
+    "data: {\"id\":\"c1\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"cmd\\\":\\\"ls\\\"}\"}},{\"index\":1,\"function\":{\"arguments\":\"{\\\"cmd\\\":\\\"pwd\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
+    "data: {\"id\":\"c1\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+    "data: [DONE]\n\n",
+);
+
+/// Regression: the Codex WS two-turn flow with PARALLEL tool calls. Turn 1
+/// returns two function_call items; turn 2 re-sends previous_response_id with
+/// both outputs. The translated chat body must keep both calls in ONE
+/// assistant message followed by both tool messages — splitting them into
+/// consecutive assistant messages makes Console Go 400 ("insufficient tool
+/// messages following tool_calls message").
+#[tokio::test]
+async fn ws_parallel_tool_turn_rebuild_produces_valid_chat_messages() {
+    use futures::{SinkExt, StreamExt};
+    use std::sync::Mutex;
+    use tokio_tungstenite::tungstenite::Message;
+
+    let captured: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
+    let cap = captured.clone();
+    let upstream_app = Router::new().route(
+        "/v1/chat/completions",
+        post(move |body: axum::body::Bytes| async move {
+            let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            cap.lock().unwrap().push(v.clone());
+            axum::response::Response::builder()
+                .header("content-type", "text/event-stream")
+                .body(axum::body::Body::from(TOOL_SSE.to_string()))
+                .unwrap()
+        }),
+    );
+    let upstream_url = spawn(upstream_app).await;
+
+    let mut providers = BTreeMap::new();
+    providers.insert(
+        "test".to_string(),
+        Provider {
+            id: "test".into(),
+            name: "Test".into(),
+            protocol: ProviderProtocol::OpenAI,
+            base_url: format!("{upstream_url}/v1"),
+            api_key: Some("sk-test".into()),
+            has_key: true,
+            context_window: None,
+            user_agent: None,
+            models: vec![ProviderModel {
+                id: "m".into(),
+                label: None,
+                enabled: true,
+            }],
+            enabled: true,
+        },
+    );
+    let config = AppConfig {
+        port: 0,
+        providers,
+        ..AppConfig::default()
+    };
+    let proxy_url = spawn(proxy::router(
+        Arc::new(RwLock::new(config)),
+        Arc::new(RwLock::new(Stats::in_memory())),
+    ))
+    .await;
+    let ws_url = format!(
+        "{}/v1/responses?token={}",
+        proxy_url.replacen("http", "ws", 1),
+        proxy::local_token()
+    );
+
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&ws_url).await.unwrap();
+
+    // Turn 1: plain user turn; upstream answers with two parallel tool calls.
+    ws.send(Message::Text(
+        serde_json::json!({
+            "type": "response.create",
+            "model": "test/m",
+            "input": [{"role":"user","content":[{"type":"input_text","text":"list files"}]}],
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .unwrap();
+    let mut resp1 = String::new();
+    let mut call_ids: Vec<String> = Vec::new();
+    while let Some(Ok(Message::Text(frame))) = ws.next().await {
+        let ev: serde_json::Value = serde_json::from_str(&frame).unwrap();
+        match ev["type"].as_str() {
+            Some("response.output_item.done") => {
+                if ev["item"]["type"] == "function_call" {
+                    call_ids.push(ev["item"]["call_id"].as_str().unwrap().to_string());
+                }
+            }
+            Some("response.completed") => {
+                resp1 = ev["response"]["id"].as_str().unwrap().to_string();
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(call_ids.len(), 2, "expected two function_call items");
+    assert!(!resp1.is_empty(), "turn 1 never completed");
+
+    // Turn 2: both tool results arrive; Codex continues with previous_response_id.
+    let outputs: Vec<serde_json::Value> = call_ids
+        .iter()
+        .map(|id| {
+            serde_json::json!({
+                "type": "function_call_output",
+                "call_id": id,
+                "output": "ok",
+            })
+        })
+        .collect();
+    ws.send(Message::Text(
+        serde_json::json!({
+            "type": "response.create",
+            "model": "test/m",
+            "previous_response_id": resp1,
+            "input": outputs,
+        })
+        .to_string()
+        .into(),
+    ))
+    .await
+    .unwrap();
+    while let Some(Ok(Message::Text(frame))) = ws.next().await {
+        let ev: serde_json::Value = serde_json::from_str(&frame).unwrap();
+        if ev["type"] == "response.completed" {
+            break;
+        }
+    }
+    ws.close(None).await.unwrap();
+
+    let bodies = captured.lock().unwrap();
+    assert!(
+        bodies.len() >= 2,
+        "expected two upstream requests, got {bodies:?}"
+    );
+    let turn2 = &bodies[1];
+    let msgs = turn2["messages"].as_array().unwrap();
+    assert_eq!(msgs[0]["role"], "user");
+    assert_eq!(msgs[1]["role"], "assistant");
+    let calls = msgs[1]["tool_calls"].as_array().unwrap();
+    assert_eq!(
+        calls.len(),
+        2,
+        "parallel calls must share one assistant message:\n{}",
+        serde_json::to_string_pretty(turn2).unwrap()
+    );
+    assert_eq!(msgs[2]["role"], "tool");
+    assert_eq!(msgs[2]["tool_call_id"], call_ids[0]);
+    assert_eq!(msgs[3]["role"], "tool");
+    assert_eq!(msgs[3]["tool_call_id"], call_ids[1]);
+}
+
 // ---------------------------------------------------------------------------
 // Responses-protocol upstream (e.g. OpenCode Zen GPT models)
 // ---------------------------------------------------------------------------

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,33 @@ import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
 import { afterEach, beforeEach } from 'vitest'
 
+// Node >= 25 exposes an experimental global `localStorage` that shadows
+// jsdom's and resolves to `undefined` unless `--localstorage-file` is passed.
+// The setup clears it after every test, so restore a working Storage now to
+// keep the suite green under both Node and Bun.
+if (typeof window.localStorage === 'undefined') {
+  const store = new Map<string, string>()
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(String(k), String(v))
+      },
+      removeItem: (k: string) => {
+        store.delete(k)
+      },
+      clear: () => {
+        store.clear()
+      },
+      key: (i: number) => [...store.keys()][i] ?? null,
+      get length() {
+        return store.size
+      },
+    },
+  })
+}
+
 // jsdom implements neither of these, and Radix (Select, Dialog) calls both
 // on mount. Without them every test that opens a menu or a modal throws.
 beforeEach(() => {


### PR DESCRIPTION
## Problem

Every engineering prompt that used a tool failed on macOS with a 400 from strict upstreams (OpenCode Go / Console Go / DeepSeek):

```
An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'.
```

Plain chat worked; only tool-using turns failed — and only on the Codex desktop app (Windows/CLI was unaffected).

## Root cause

Two translation bugs in `responses_to_chat` combined:

1. **Parallel tool calls** arrived as consecutive `function_call` items and were translated into separate `assistant` messages, so a `tool_calls` message was never immediately answered by its tool messages.
2. **Codex's macOS app** interleaves a `developer` (→ `system`) item between the assistant's tool calls and their outputs, landing a `system` message in the middle of the tool sequence.

## Fix

- Consecutive `function_call` items now merge into a single `assistant` message with one `tool_calls` array.
- `hoist_interleaved_system` moves any `system` message that ended up inside a tool block to just before the `tool_calls` message.

Verified end-to-end against the real upstream: the exact failing payload now returns 200.

## Tests

- `parallel_function_calls_merge_into_one_assistant_message` (unit)
- `interleaved_developer_message_does_not_break_tool_sequence` (unit)
- `ws_parallel_tool_turn_rebuild_produces_valid_chat_messages` (e2e, WS two-turn rebuild)

Also: a localStorage polyfill in the vitest setup so the frontend suite passes under Node >= 25, and the 0.2.5 version bump + changelog.

## Checks

- `cargo test` 88 passed
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- `bun run lint` / `bun run test` (45) / `bun run build` green