### PR TITLE
release: 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 Written for the person installing the build. Internal churn is left out.
 
-## Unreleased
+## 0.2.5
 
 ### Fixed
 
-- Follow-up to 0.2.4 (not released yet — waiting on a version bump): the step that asks your shell where Codex lives now
+- **Tool calls stopped working with strict upstreams (OpenCode Go / Console Go / DeepSeek) on the Codex desktop app.** Two translation bugs combined into one failing turn: parallel tool calls were split into separate assistant messages, and Codex's macOS app interleaves a `developer` (system) message between the assistant's tool calls and their results. Either way the request reached the upstream with a `tool_calls` message that was never immediately answered, and the API rejected it with "an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'." Every engineering prompt that reached for a tool failed on a Mac while the same setup worked on Windows, because the desktop client sends that interleaved item and the CLI does not.
+
+  Parallel calls now share a single assistant message, and interleaved system messages are hoisted in front of the `tool_calls` message so the tool sequence stays contiguous. Plain chat was never affected, which is why the failure only showed up once tools were in play.
+
+- **Routed models could not use multi-agent or MCP tools.** The Responses format carries five tool shapes and only the plain function was forwarded; everything else was dropped silently. A real request arrives with 23 tool entries and 12 survive. Gone with them were the whole multi-agent surface (`namespace[collaboration]` — spawn_agent, wait_agent, send_message, followup_task, list_agents, interrupt_agent), `custom[apply_patch]`, and every MCP server configured (Grafana's 56 tools, pentest-ai's 50, context7, context-mode, node_repl). A dropped tool is indistinguishable from a tool the model was never given, which is why this presented for months as "routed models can't use MCP" rather than as an error. Namespaces are now unpacked into their inner functions and `custom` is forwarded.
+
+- **The multi-agent toggle reported success while doing nothing.** It wrote `[features] multi_agent` — Codex's v1 collab surface, where the spawn tool is registered as `collaboration.spawn_agent` — while the orchestrator skill tells the model to call `spawn_agent`. No tool by that name existed, so the model reported having none and did the whole task itself. The toggle now writes `multi_agent_v2` (the flag that yields the plain name) and the merged catalog declares "v2" for routed models, matching what native entries already said.
+
+- Follow-up to 0.2.4: the step that asks your shell where Codex lives now
   actually asks an interactive shell. zsh is the macOS default and only
   reads `.zshrc` for interactive shells — `.zprofile` and `.zlogin` cover
   login ones — so a login-only probe returned nothing on the setup it was
@@ -17,6 +25,16 @@ Written for the person installing the build. Internal churn is left out.
   carry its weight, which is what matters when Codex is installed somewhere
   unusual. The probe is bounded by a deadline so a slow shell profile cannot
   hang the screen that waits on it.
+
+### Changed
+
+- **The orchestrator skill stays in sync on every launch.** It was only
+  rewritten when an agent was added or deleted, so an improvement to its
+  text reached new installs and never existing ones — a user whose roster
+  was already set up kept the version shipped the day they created their
+  first agent. Syncing at startup makes the skill a product surface that can
+  be corrected in a release rather than a file frozen at first write. A skill
+  that cannot be written is a warning, never a refusal to start.
 
 ## 0.2.4
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loom-router",
   "private": true,
-  "version": "0.2.4",
+  "version": "0.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2239,7 +2239,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom-router"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "loom-router"
 # Kept in lockstep with package.json and tauri.conf.json; the release
 # workflow verifies all three against the tag.
-version = "0.2.4"
+version = "0.2.5"
 description = "Weave any model into your coding agent's picker."
 authors = ["LoomRouter contributors"]
 license = "MIT"

--- a/src-tauri/src/translate.rs
+++ b/src-tauri/src/translate.rs
@@ -178,25 +178,7 @@ pub fn responses_to_chat(payload: &Value, model: &str, unified_reasoning: bool) 
         // of type `function`. A dropped tool looks exactly like a tool the
         // model was never given, so this failed as "the model can't use MCP"
         // rather than as an error.
-        let (chat_tools, namespaces) = flatten_tools(tools);
-        // TEMPORARY — revert this commit once routed multi-agent and MCP are
-        // confirmed working end to end.
-        //
-        // Counts and namespace names only: no parameters, no descriptions, so
-        // request bodies stay out of the logs. It is `warn` so it shows in a
-        // plain `tauri dev` run, which is also why it should not ship — every
-        // routed request logs a line.
-        {
-            let mut unpacked: Vec<&str> = namespaces.values().map(String::as_str).collect();
-            unpacked.sort_unstable();
-            unpacked.dedup();
-            tracing::warn!(
-                "TOOLS-DEBUG {} entries in -> {} functions out, namespaces unpacked: [{}]",
-                tools.len(),
-                chat_tools.len(),
-                unpacked.join(", ")
-            );
-        }
+        let (chat_tools, _) = flatten_tools(tools);
         if !chat_tools.is_empty() {
             out["tools"] = Value::Array(chat_tools);
         }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoomRouter",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "identifier": "dev.loomrouter.app",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Version bump and changelog for **0.2.5** (the tool-call fix already landed on main via #14).

## What's in this PR

- Bump to 0.2.5 in all three version files (package.json, Cargo.toml, tauri.conf.json) + Cargo.lock.
- Write the `## 0.2.5` changelog section covering everything since 0.2.4:
  - tool calls staying contiguous for strict upstreams (the #14 fix),
  - multi-agent / MCP tool flattening,
  - the `multi_agent_v2` flag,
  - orchestrator-skill sync on launch,
  - the pending 0.2.4 shell-probe follow-up.
- **Reverts the temporary tool-shape instrumentation** (`6fe2613`) — its own message marks it as must-not-ship (logs a line on every routed request).

After merge: tag `v0.2.5` triggers the release workflow (Windows + macOS installers) with the changelog section as the release body.