### PR TITLE
fix(providers): report real context windows for OpenCode Zen/Go models

### DIFF
--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -784,10 +784,18 @@ mod tests {
         // The gateway publishes two catalog entries; the app splits each into
         // three presets by dialect. Every preset must resolve, or models.dev
         // enrichment silently no-ops and its models fall back to 128k.
-        for zen in ["opencode-zen-chat", "opencode-zen-claude", "opencode-zen-responses"] {
+        for zen in [
+            "opencode-zen-chat",
+            "opencode-zen-claude",
+            "opencode-zen-responses",
+        ] {
             assert_eq!(models_dev_key(zen), "opencode");
         }
-        for go in ["opencode-go-chat", "opencode-go-claude", "opencode-go-responses"] {
+        for go in [
+            "opencode-go-chat",
+            "opencode-go-claude",
+            "opencode-go-responses",
+        ] {
             assert_eq!(models_dev_key(go), "opencode-go");
         }
         // Providers whose slug already matches the catalog pass through.

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -658,11 +658,18 @@ async fn fetch_balance(p: &crate::config::Provider) -> ProviderBalance {
 const MODELS_DEV_URL: &str = "https://models.dev/api.json";
 
 /// The models.dev catalog key for one of our provider ids, where the two
-/// catalogs use different slugs.
+/// catalogs use different slugs. The gateway publishes two catalog entries —
+/// `opencode` (Zen) and `opencode-go` (Go) — while the app splits each into
+/// three presets by dialect. Only `opencode-go-chat` was mapped, so the other
+/// five looked up a key that does not exist and models.dev enrichment silently
+/// no-oped, leaving every model on those providers at the conservative 128k.
 fn models_dev_key(provider_id: &str) -> &str {
-    match provider_id {
-        "opencode-go-chat" => "opencode-go",
-        other => other,
+    if provider_id.starts_with("opencode-zen-") {
+        "opencode"
+    } else if provider_id.starts_with("opencode-go-") {
+        "opencode-go"
+    } else {
+        provider_id
     }
 }
 
@@ -773,8 +780,16 @@ mod tests {
     }
 
     #[test]
-    fn models_dev_key_maps_divergent_slugs() {
-        assert_eq!(models_dev_key("opencode-go-chat"), "opencode-go");
+    fn models_dev_key_maps_all_opencode_presets() {
+        // The gateway publishes two catalog entries; the app splits each into
+        // three presets by dialect. Every preset must resolve, or models.dev
+        // enrichment silently no-ops and its models fall back to 128k.
+        for zen in ["opencode-zen-chat", "opencode-zen-claude", "opencode-zen-responses"] {
+            assert_eq!(models_dev_key(zen), "opencode");
+        }
+        for go in ["opencode-go-chat", "opencode-go-claude", "opencode-go-responses"] {
+            assert_eq!(models_dev_key(go), "opencode-go");
+        }
         // Providers whose slug already matches the catalog pass through.
         assert_eq!(models_dev_key("openrouter"), "openrouter");
         assert_eq!(models_dev_key("kimi-coding"), "kimi-coding");

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,16 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Context window (tokens) as a compact tag: "1M", "1.05M", "256K".
+ * Windows are published by the backend in raw tokens (e.g. kimi-k3 =
+ * 1_048_576), so 1M-class models must not render as "1.048576M".
+ */
+export function formatContextWindow(window: number): string {
+  if (window >= 1_000_000) {
+    const m = window / 1_000_000
+    return m >= 10 ? `${Math.round(m)}M` : `${m.toFixed(2).replace(/\.?0+$/, '')}M`
+  }
+  return `${Math.round(window / 1024)}K`
+}

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -3,6 +3,7 @@ import { CheckCircle2, XCircle } from 'lucide-react'
 import { api } from '@/lib/api'
 import { useBackendState } from '@/lib/events'
 import { useStrings } from '@/i18n'
+import { formatContextWindow } from '@/lib/utils'
 import type {
   AppConfig,
   ContextWindow,
@@ -83,9 +84,7 @@ function ModelRow({ m, window: ctx }: { m: ModelAggregate; window?: ContextWindo
                 : 'border-dashed border-border text-muted-foreground/60')
             }
           >
-            {ctx.window >= 1_000_000
-              ? `${ctx.window / 1_000_000}M`
-              : `${Math.round(ctx.window / 1024)}K`}
+            {formatContextWindow(ctx.window)}
             {!ctx.known && ' ?'}
           </span>
         )}

--- a/src/pages/Providers.tsx
+++ b/src/pages/Providers.tsx
@@ -3,6 +3,7 @@ import { Pencil, Plus, RefreshCw, Trash2 } from 'lucide-react'
 import { api } from '@/lib/api'
 import { useBackendState } from '@/lib/events'
 import { useStrings } from '@/i18n'
+import { formatContextWindow } from '@/lib/utils'
 import { PRESETS, type AppConfig, type ContextWindow, type Provider } from '@/types'
 import PageShell, { CARD_GRID } from '@/components/PageShell'
 import { Button } from '@/components/ui/button'
@@ -324,7 +325,7 @@ function EditProviderDialog({ provider, onSaved }: { provider: Provider; onSaved
 function ContextWindowTag({ info }: { info?: ContextWindow }) {
   const s = useStrings()
   if (!info) return null
-  const t = info.window >= 1_000_000 ? `${info.window / 1_000_000}M` : `${Math.round(info.window / 1024)}K`
+  const t = formatContextWindow(info.window)
   return (
     <span
       title={info.known ? s.providers.contextKnown : s.providers.contextGuess}


### PR DESCRIPTION
## Summary

Models served by the OpenCode Zen/Go gateway were reported as **128k** even when they have a **1M** context window (e.g. `deepseek-v4-pro`, `glm-5.2`, `qwen3.6-plus`).

The app already resolves windows from the [models.dev](https://models.dev) catalog at runtime (`enrich_from_models_dev`, hourly cache). The bug was that only one of the six OpenCode presets was mapped to a catalog key:

```rust
fn models_dev_key(provider_id: &str) -> &str {
    match provider_id {
        "opencode-go-chat" => "opencode-go",  // only this one
        other => other,
    }
}
```

The real catalog keys are `opencode` (Zen) and `opencode-go` (Go). The five unmapped presets looked up a key that doesn't exist, enrichment silently no-oped, and every model on those providers fell back to `DEFAULT_CONTEXT_WINDOW` (128k).

## Changes

- **`state.rs`**: `models_dev_key` now maps all six OpenCode presets — `opencode-zen-*` → `opencode`, `opencode-go-*` → `opencode-go` — so discovery picks up real windows (including future models) on the next hourly refresh.
- **`utils.ts`** (+ `Overview.tsx`, `Providers.tsx`): format context tags as `1M` / `1.05M` instead of `1.048576M` — `kimi-k3` and `mimo-v2-pro` (1,048,576 tokens) rendered the raw divisor.

## Verification

- `cargo test`: 108 passed
- `cargo clippy --all-targets`: clean
- `npm test`: 47 passed
