### PR TITLE
fix(router): harden catalog and native routing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
+          args: --config src-tauri/tauri.release.conf.json
           # Without an explicit tagName the action skips the release
           # creation and all uploads ("No releaseId or tagName provided").
           tagName: ${{ github.ref_name }}

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -150,7 +150,9 @@ fn login_shell_lookup() -> Option<std::path::PathBuf> {
 /// Whether this command answers `--version` successfully. Guards against
 /// stale npm shims that point at a moved or unlinked install.
 fn runs(bin: &std::path::Path) -> bool {
-    std::process::Command::new(bin)
+    let mut command = std::process::Command::new(bin);
+    hide_console_window(&mut command);
+    command
         .arg("--version")
         .env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
         .env("CLAUDE_CODE_SKIP_BACKGROUND_PREFETCH", "1")
@@ -297,6 +299,7 @@ pub async fn run_print_turn(
     let config_dir = config_dir.map(std::path::Path::to_path_buf);
     tokio::task::spawn_blocking(move || {
         let mut cmd = std::process::Command::new(&bin);
+        hide_console_window(&mut cmd);
         cmd.arg("-p")
             .arg("--model")
             .arg(&model)
@@ -525,7 +528,9 @@ pub async fn auth_status() -> ClaudeAuthStatus {
     };
     let bin = bin.clone();
     tokio::task::spawn_blocking(move || {
-        let out = std::process::Command::new(bin)
+        let mut command = std::process::Command::new(bin);
+        hide_console_window(&mut command);
+        let out = command
             .args(["auth", "status"])
             .env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
             .env("CLAUDE_CODE_SKIP_BACKGROUND_PREFETCH", "1")
@@ -592,6 +597,17 @@ pub async fn auth_status() -> ClaudeAuthStatus {
         ..Default::default()
     })
 }
+
+#[cfg(windows)]
+fn hide_console_window(command: &mut std::process::Command) {
+    use std::os::windows::process::CommandExt;
+
+    // CLI shims are console applications on Windows; this app is not.
+    command.creation_flags(0x0800_0000);
+}
+
+#[cfg(not(windows))]
+fn hide_console_window(_: &mut std::process::Command) {}
 
 /// Map Claude Code's `subscriptionType` to a UI-friendly plan name.
 fn plan_label(subscription: &str) -> String {

--- a/src-tauri/src/codex.rs
+++ b/src-tauri/src/codex.rs
@@ -182,7 +182,9 @@ fn resolve_codex_bin() -> Option<String> {
 
 /// Whether this command answers `--version` successfully.
 fn runs(bin: &str) -> bool {
-    std::process::Command::new(bin)
+    let mut command = std::process::Command::new(bin);
+    hide_console_window(&mut command);
+    command
         .arg("--version")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -291,7 +293,9 @@ pub fn capture_native_catalog(
         anyhow::anyhow!("Codex CLI not found on PATH (set CODEX_BIN to its location)")
     })?;
     let run = |extra: &str| -> anyhow::Result<String> {
-        let out = std::process::Command::new(&bin)
+        let mut command = std::process::Command::new(&bin);
+        hide_console_window(&mut command);
+        let out = command
             .args(["debug", "models"])
             .args(if extra.is_empty() {
                 vec![]
@@ -331,7 +335,8 @@ pub fn capture_native_catalog(
     if models.is_empty() {
         anyhow::bail!("Codex returned an empty or invalid model catalog");
     }
-    let catalog = json!({ "models": models });
+    let mut catalog = json!({ "models": models });
+    ensure_native_catalog_backfills(&mut catalog);
     std::fs::create_dir_all(loom_dir())?;
     std::fs::write(
         native_catalog_path(),
@@ -340,11 +345,50 @@ pub fn capture_native_catalog(
     Ok(catalog)
 }
 
+#[cfg(windows)]
+fn hide_console_window(command: &mut std::process::Command) {
+    use std::os::windows::process::CommandExt;
+
+    // The Desktop CLI has no UI; hiding its inherited console avoids a flash.
+    command.creation_flags(0x0800_0000);
+}
+
+#[cfg(not(windows))]
+fn hide_console_window(_: &mut std::process::Command) {}
+
 fn load_native_catalog() -> Value {
-    std::fs::read_to_string(native_catalog_path())
+    let mut catalog = std::fs::read_to_string(native_catalog_path())
         .ok()
         .and_then(|s| serde_json::from_str(&s).ok())
-        .unwrap_or_else(|| json!({ "models": [] }))
+        .unwrap_or_else(|| json!({ "models": [] }));
+    ensure_native_catalog_backfills(&mut catalog);
+    catalog
+}
+
+/// Keep a release-known native entry available when an older or sandboxed
+/// Codex CLI omits it from `debug models`. Clone Terra's real schema instead
+/// of inventing one, so the picker gets the same contract Codex expects.
+fn ensure_native_catalog_backfills(catalog: &mut Value) {
+    let Some(models) = catalog.get_mut("models").and_then(Value::as_array_mut) else {
+        return;
+    };
+    if models
+        .iter()
+        .any(|model| model.get("slug").and_then(Value::as_str) == Some("gpt-5.6-sol"))
+    {
+        return;
+    }
+    let Some(mut sol) = models
+        .iter()
+        .find(|model| model.get("slug").and_then(Value::as_str) == Some("gpt-5.6-terra"))
+        .cloned()
+    else {
+        return;
+    };
+    sol["slug"] = json!("gpt-5.6-sol");
+    sol["display_name"] = json!("GPT-5.6-Sol");
+    sol["priority"] = json!(4);
+    models.push(sol);
 }
 
 /// Conservative fallback context window (tokens) for providers without an
@@ -2145,6 +2189,26 @@ mod tests {
         // heuristic must NOT apply; without an explicit override the
         // conservative default is published.
         assert_eq!(ext["context_window"], DEFAULT_CONTEXT_WINDOW);
+    }
+
+    #[test]
+    fn native_catalog_backfills_sol_from_terra_when_the_cli_omits_it() {
+        let mut native = json!({"models": [
+            {"slug": "gpt-5.6-terra", "display_name": "GPT-5.6-Terra", "priority": 2,
+             "visibility": "list", "supported_in_api": true}
+        ]});
+
+        ensure_native_catalog_backfills(&mut native);
+
+        let sol = native["models"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|model| model["slug"] == "gpt-5.6-sol")
+            .unwrap();
+        assert_eq!(sol["display_name"], "GPT-5.6-Sol");
+        assert_eq!(sol["priority"], 4);
+        assert_eq!(sol["visibility"], "list");
     }
 
     #[test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -190,6 +190,10 @@ pub fn config_path() -> PathBuf {
     config_dir().join("config.json")
 }
 
+pub fn is_gpt_model_id(model_id: &str) -> bool {
+    model_id.trim().to_ascii_lowercase().starts_with("gpt-")
+}
+
 impl AppConfig {
     pub fn load() -> Self {
         let path = config_path();
@@ -206,6 +210,7 @@ impl AppConfig {
                     cfg.onboarding_completed = Some(true);
                 }
                 cfg.merge_opencode_dialect_providers();
+                cfg.prune_external_gpt_models();
                 cfg
             }
             // No config file at all: a genuinely fresh install, so the
@@ -292,6 +297,47 @@ impl AppConfig {
                 self.migrated = true;
             }
         }
+    }
+
+    /// GPT models are supplied by Codex's native catalog. Keeping mirrored
+    /// upstream entries would let an external provider shadow that catalog.
+    fn prune_external_gpt_models(&mut self) {
+        let mut removed = false;
+        for provider in self.providers.values_mut() {
+            let before = provider.models.len();
+            provider.models.retain(|model| !is_gpt_model_id(&model.id));
+            removed |= provider.models.len() != before;
+        }
+        if !removed {
+            return;
+        }
+
+        let is_removed_slug = |slug: &str| {
+            slug.rsplit_once('/')
+                .is_some_and(|(_, model)| is_gpt_model_id(model))
+        };
+        if self.active_model.as_deref().is_some_and(is_removed_slug) {
+            self.active_model = None;
+        }
+        if self
+            .side_call_fallback
+            .as_deref()
+            .is_some_and(is_removed_slug)
+        {
+            self.side_call_fallback = None;
+        }
+        if self
+            .visual_assistance
+            .assistant_model
+            .as_deref()
+            .is_some_and(is_removed_slug)
+        {
+            self.visual_assistance.assistant_model = None;
+        }
+        self.visual_assistance
+            .fallback_models
+            .retain(|slug| !is_removed_slug(slug));
+        self.migrated = true;
     }
 
     /// Repoint every `provider/model` reference from one provider id to
@@ -537,6 +583,34 @@ mod tests {
         assert!(cfg.providers.contains_key("opencode-go-chat"));
         assert!(!cfg.providers.contains_key("opencode-go"));
         assert!(!cfg.migrated);
+    }
+
+    #[test]
+    fn pruning_external_gpt_models_removes_them_and_their_saved_references() {
+        let mut cfg = AppConfig::default();
+        cfg.providers.insert(
+            "external".into(),
+            opencode_part(
+                "external",
+                ProviderProtocol::OpenAI,
+                &["gpt-5.6", "kimi-k3"],
+            ),
+        );
+        cfg.active_model = Some("external/gpt-5.6".into());
+        cfg.side_call_fallback = Some("external/gpt-5.6".into());
+        cfg.visual_assistance.assistant_model = Some("external/gpt-5.6".into());
+        cfg.visual_assistance.fallback_models =
+            vec!["external/gpt-5.6".into(), "external/kimi-k3".into()];
+
+        cfg.prune_external_gpt_models();
+
+        assert_eq!(cfg.providers["external"].models.len(), 1);
+        assert_eq!(cfg.providers["external"].models[0].id, "kimi-k3");
+        assert!(cfg.active_model.is_none());
+        assert!(cfg.side_call_fallback.is_none());
+        assert!(cfg.visual_assistance.assistant_model.is_none());
+        assert_eq!(cfg.visual_assistance.fallback_models, ["external/kimi-k3"]);
+        assert!(cfg.migrated);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -755,6 +755,10 @@ pub fn run() {
                 if let Err(e) = state.persist_migration().await {
                     tracing::warn!("persisting the migrated config failed: {e}");
                 }
+                // Codex can ship a new native model between LoomRouter
+                // launches. Refresh our generated files before the proxy
+                // starts so the picker cannot remain stuck on an old capture.
+                state.repair_codex_integration().await;
                 if let Err(e) = state.server_start().await {
                     tracing::warn!("proxy autostart failed: {e}");
                 }

--- a/src-tauri/src/providers.rs
+++ b/src-tauri/src/providers.rs
@@ -253,6 +253,7 @@ impl Provider {
             models: preset
                 .default_models
                 .iter()
+                .filter(|model| !crate::config::is_gpt_model_id(model.id))
                 .map(|m| crate::config::ProviderModel {
                     id: m.id.to_string(),
                     label: claude_code_label(m.id),

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -20,7 +20,7 @@ use axum::{
     body::Body,
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
-        Request, State as AxState,
+        DefaultBodyLimit, Request, State as AxState,
     },
     http::{HeaderMap, StatusCode},
     middleware::{self, Next},
@@ -34,6 +34,10 @@ use serde_json::{json, Value};
 use std::collections::VecDeque;
 use std::fmt;
 use std::sync::{Arc, Mutex, OnceLock};
+
+// Codex remote compaction can legitimately carry a multi-megabyte transcript.
+// Keep a finite bound while exceeding Axum's 2 MiB default for `Bytes`.
+const MAX_REQUEST_BODY_BYTES: usize = 16 * 1024 * 1024;
 
 #[derive(Clone)]
 struct ProxyCtx {
@@ -240,6 +244,7 @@ pub fn router(config: SharedConfig, stats: SharedStats) -> Router {
         // The Codex App sends request bodies compressed (gzip/br/zstd).
         // Decompress transparently before handlers see the bytes.
         .layer(tower_http::decompression::RequestDecompressionLayer::new())
+        .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
         // Every route (including /health and the WS upgrade) requires the
         // local token; see `auth_gate`.
         .layer(middleware::from_fn(auth_gate))
@@ -1529,8 +1534,9 @@ async fn forward_native(
     ctx: &ProxyCtx,
     wire: WireApi,
     headers: &HeaderMap,
-    payload: Value,
+    mut payload: Value,
 ) -> anyhow::Result<Response> {
+    sanitize_native_payload(&mut payload);
     let upstream = native_send(ctx, wire, headers, &payload).await?;
     let status =
         StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
@@ -1538,6 +1544,14 @@ async fn forward_native(
     Ok(Response::builder()
         .status(status)
         .body(Body::from_stream(upstream.bytes_stream()))?)
+}
+
+fn sanitize_native_payload(payload: &mut Value) {
+    // Codex marks an internal generation mode that this Responses upstream
+    // does not expose. It does not change the prompt, model, or tool shape.
+    if let Some(object) = payload.as_object_mut() {
+        object.remove("generate");
+    }
 }
 
 /// Headers relayed to the native backend so ChatGPT auth and session
@@ -1876,6 +1890,16 @@ fn rebuild_input(history: &WsHistory, prev: Option<&str>, delta: Vec<Value>) -> 
     }
 }
 
+/// Responses sent to the native upstream cannot carry Codex's continuation
+/// handle. The proxy has already rebuilt that handle into a complete input,
+/// so forward the portable form instead of a parameter this backend rejects.
+fn replace_incremental_input(payload: &mut Value, input: Vec<Value>) {
+    payload["input"] = Value::Array(input);
+    if let Some(object) = payload.as_object_mut() {
+        object.remove("previous_response_id");
+    }
+}
+
 async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
     let (mut tx, mut rx) = socket.split();
 
@@ -1942,6 +1966,7 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
             let history = ctx.history.lock().unwrap_or_else(|e| e.into_inner());
             rebuild_input(&history, prev.as_deref(), delta)
         };
+        replace_incremental_input(&mut payload, items.clone());
         let mut full_input_items: Option<Vec<Value>> = Some(items.clone());
         if let Some((provider, upstream_model)) = &routed {
             // Stateless routed upstreams reject inputs beyond their window and
@@ -1981,10 +2006,7 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
                 };
                 fit.insert(0, marker);
             }
-            payload["input"] = Value::Array(fit.clone());
-            if let Some(m) = payload.as_object_mut() {
-                m.remove("previous_response_id");
-            }
+            replace_incremental_input(&mut payload, fit.clone());
             full_input_items = Some(fit);
         }
 
@@ -2034,7 +2056,7 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
         let mut completed_response_id: Option<String> = None;
 
         match ws_turn_events(&ctx, &headers, payload).await {
-            Ok(mut events) => {
+            Ok((mut events, final_provider)) => {
                 while let Some(item) = events.next().await {
                     let frame = match &item {
                         Ok(v) => v.clone(),
@@ -2052,14 +2074,10 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
                                     .pointer("/response/id")
                                     .and_then(Value::as_str)
                                     .map(str::to_string);
-                                let label = routed
-                                    .as_ref()
-                                    .map(|(p, _)| p.id.clone())
-                                    .unwrap_or_else(|| "codex-native".to_string());
                                 // Canonical Responses frames on this transport.
                                 record_payload_usage(
                                     &ctx.stats,
-                                    &label,
+                                    &final_provider,
                                     &model,
                                     "ws",
                                     Some(turn_start),
@@ -2085,14 +2103,10 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
                     }
                 }
             }
-            Err(e) => {
-                let label = routed
-                    .as_ref()
-                    .map(|(p, _)| p.id.clone())
-                    .unwrap_or_else(|| "codex-native".to_string());
+            Err((e, final_provider)) => {
                 record_failure(
                     &ctx.stats,
-                    &label,
+                    &final_provider,
                     &model,
                     "ws",
                     Some(turn_start),
@@ -2124,15 +2138,20 @@ fn ws_error_frame(status: u16, message: &str) -> Value {
 
 /// Run one turn and return a stream of Responses event objects ready to be
 /// sent as WS text frames.
-async fn ws_turn_events(
-    ctx: &ProxyCtx,
-    headers: &HeaderMap,
-    payload: Value,
-) -> anyhow::Result<futures::stream::BoxStream<'static, Result<Value, String>>> {
+type WsEvents = futures::stream::BoxStream<'static, Result<Value, String>>;
+type LabeledWsEvents = Result<(WsEvents, String), (anyhow::Error, String)>;
+
+fn label_ws_events(result: anyhow::Result<WsEvents>, provider_id: String) -> LabeledWsEvents {
+    result
+        .map(|events| (events, provider_id.clone()))
+        .map_err(|error| (error, provider_id))
+}
+
+async fn ws_turn_events(ctx: &ProxyCtx, headers: &HeaderMap, payload: Value) -> LabeledWsEvents {
     let model = payload
         .get("model")
         .and_then(Value::as_str)
-        .ok_or_else(|| anyhow!("missing 'model' field"))?
+        .ok_or_else(|| (anyhow!("missing 'model' field"), "codex-native".to_string()))?
         .to_string();
 
     let route = {
@@ -2141,7 +2160,10 @@ async fn ws_turn_events(
     };
     match route {
         // Native GPT model: relay the backend's SSE events as WS frames.
-        EffectiveRoute::Native => ws_native_events(ctx, headers, payload).await,
+        EffectiveRoute::Native => label_ws_events(
+            ws_native_events(ctx, headers, payload).await,
+            "codex-native".to_string(),
+        ),
         EffectiveRoute::Routed {
             provider,
             upstream_model,
@@ -2154,7 +2176,7 @@ async fn ws_turn_events(
                 ws_routed_events(ctx, &provider, &upstream_model, &model, &payload).await
             };
             if !from_fallback || attempt.is_ok() {
-                return attempt;
+                return label_ws_events(attempt, provider.id);
             }
             // A failed fallback must never break a side call: retry against
             // the request's original destination (same rule as HTTP).
@@ -2165,13 +2187,17 @@ async fn ws_turn_events(
             };
             match original {
                 Ok((p, upstream_model)) => {
-                    if p.id == crate::providers::CLAUDE_CODE_PROVIDER_ID {
+                    let retry = if p.id == crate::providers::CLAUDE_CODE_PROVIDER_ID {
                         ws_claude_cli_events(ctx, &p, &upstream_model, &model, &payload).await
                     } else {
                         ws_routed_events(ctx, &p, &upstream_model, &model, &payload).await
-                    }
+                    };
+                    label_ws_events(retry, p.id)
                 }
-                Err(_) => ws_native_events(ctx, headers, payload).await,
+                Err(_) => label_ws_events(
+                    ws_native_events(ctx, headers, payload).await,
+                    "codex-native".to_string(),
+                ),
             }
         }
     }
@@ -2181,8 +2207,9 @@ async fn ws_turn_events(
 async fn ws_native_events(
     ctx: &ProxyCtx,
     headers: &HeaderMap,
-    payload: Value,
+    mut payload: Value,
 ) -> anyhow::Result<futures::stream::BoxStream<'static, Result<Value, String>>> {
+    sanitize_native_payload(&mut payload);
     let upstream = native_send(ctx, WireApi::Responses, headers, &payload).await?;
     let status = upstream.status();
     if !status.is_success() {
@@ -3442,6 +3469,31 @@ mod tests {
         let rebuilt = rebuild_input(&history, Some("never-cached"), vec![history_item("d")]);
         assert_eq!(rebuilt.len(), 1);
         assert_eq!(rebuilt[0]["id"], "d");
+    }
+
+    #[test]
+    fn native_follow_up_replaces_previous_response_id_with_rebuilt_input() {
+        let mut payload = json!({
+            "model": "gpt-5.6-sol",
+            "previous_response_id": "resp_1",
+            "input": [history_item("new")],
+        });
+        let full_input = vec![history_item("old"), history_item("new")];
+
+        replace_incremental_input(&mut payload, full_input.clone());
+
+        assert_eq!(payload["input"], json!(full_input));
+        assert!(payload.get("previous_response_id").is_none());
+    }
+
+    #[test]
+    fn native_payload_strips_the_unsupported_generate_flag() {
+        let mut payload = json!({"model": "gpt-5.6-terra", "generate": true});
+
+        sanitize_native_payload(&mut payload);
+
+        assert!(payload.get("generate").is_none());
+        assert_eq!(payload["model"], "gpt-5.6-terra");
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -112,6 +112,34 @@ impl AppState {
         }
     }
 
+    /// Rebuild generated Codex files once per LoomRouter launch. The Codex
+    /// catalog changes independently of this app, so trusting the previous
+    /// capture strands new native models outside the picker until a user
+    /// happens to edit a provider or presses Apply again.
+    pub async fn repair_codex_integration(&self) {
+        match self
+            .repair_codex_integration_with(|config, port| codex::apply(&config, port))
+            .await
+        {
+            Ok(true) => tracing::info!("Codex integration catalog refreshed at startup"),
+            Ok(false) => {}
+            Err(e) => tracing::warn!("startup repair of Codex integration failed: {e}"),
+        }
+    }
+
+    async fn repair_codex_integration_with<F>(&self, regenerate: F) -> anyhow::Result<bool>
+    where
+        F: FnOnce(AppConfig, u16) -> anyhow::Result<()> + Send + 'static,
+    {
+        let cfg = self.config.read().await.clone();
+        if !cfg.codex_integration {
+            return Ok(false);
+        }
+        let port = cfg.port;
+        tokio::task::spawn_blocking(move || regenerate(cfg, port)).await??;
+        Ok(true)
+    }
+
     pub async fn save_provider(&self, mut provider: crate::config::Provider) -> anyhow::Result<()> {
         let mut cfg = self.config.write().await;
         // The UI never receives the real key back, so an empty key on save
@@ -191,6 +219,22 @@ impl AppState {
             .get(provider_id)
             .and_then(|m| m.get(model))
             .copied();
+        // A multi-dialect gateway's catalog does not say which endpoint a
+        // model accepts. Validate before exposing a newly enabled model, so
+        // Codex never routes its first real turn through a guessed wire.
+        let detected_protocol = if enabled {
+            let provider = self
+                .config
+                .read()
+                .await
+                .providers
+                .get(provider_id)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("unknown provider '{provider_id}'"))?;
+            Some(probe_model_dialect(&provider, model).await?)
+        } else {
+            None
+        };
         let mut cfg = self.config.write().await;
         let provider = cfg
             .providers
@@ -198,6 +242,9 @@ impl AppState {
             .ok_or_else(|| anyhow::anyhow!("unknown provider '{provider_id}'"))?;
         if let Some(m) = provider.models.iter_mut().find(|m| m.id == model) {
             m.enabled = enabled;
+            if let Some(protocol) = detected_protocol {
+                m.protocol = Some(protocol);
+            }
             if provider.id == crate::providers::CLAUDE_CODE_PROVIDER_ID {
                 m.context_window = crate::providers::claude_code_context(model);
                 m.fast_mode = crate::providers::claude_code_fast_mode(model);
@@ -207,11 +254,7 @@ impl AppState {
                 id: model.to_string(),
                 label: crate::providers::claude_code_label(model),
                 context_window: discovered_context,
-                // Discovery reports ids, never dialects — no catalog
-                // publishes which wire a gateway serves a model on. The
-                // provider's own is the assumption until the user says
-                // otherwise in the model's dialect picker.
-                protocol: None,
+                protocol: detected_protocol,
                 fast_mode: if provider.id == crate::providers::CLAUDE_CODE_PROVIDER_ID {
                     crate::providers::claude_code_fast_mode(model)
                 } else {
@@ -227,11 +270,9 @@ impl AppState {
         Ok(())
     }
 
-    /// Record the wire dialect one model is served in, or clear it back to
-    /// the provider's. Only ever set by hand: no catalog publishes which
-    /// wire a gateway serves a model on, so a model discovery turned up on a
-    /// multi-dialect gateway is assumed to speak the provider's until the
-    /// user says otherwise here.
+    /// Record the wire dialect one model is served in. Kept for backwards
+    /// compatibility with existing configurations; automatic probes own the
+    /// value for models fetched or enabled in the current application.
     pub async fn set_model_protocol(
         &self,
         provider_id: &str,
@@ -418,8 +459,19 @@ impl AppState {
                 .ok_or_else(|| anyhow::anyhow!("unknown provider '{provider_id}'"))?
         };
         let mut detailed = list_models_detailed(&provider).await?;
-        self.enrich_from_models_dev(provider_id, &mut detailed)
-            .await;
+        let enabled_ids: Vec<String> = provider
+            .models
+            .iter()
+            .filter(|model| model.enabled)
+            .map(|model| model.id.clone())
+            .collect();
+        // The public capability catalog and upstream dialect checks are
+        // independent. Starting them together avoids making Fetch models wait
+        // for a multi-megabyte catalog before it validates enabled models.
+        let (_, detected_protocols) = futures::join!(
+            self.enrich_from_models_dev(provider_id, &mut detailed),
+            probe_enabled_model_dialects(&provider, provider_id, enabled_ids),
+        );
         let vision_models = self.vision_models_from_models_dev(provider_id).await;
         match &vision_models {
             Some(models) => tracing::info!(
@@ -449,38 +501,42 @@ impl AppState {
             .filter_map(|(id, ctx)| ctx.map(|c| (id.clone(), c)))
             .collect();
         if !known.is_empty() {
-            {
-                let mut cache = self.model_contexts.write().await;
-                let per_provider = cache.entry(provider_id.to_string()).or_default();
-                for (id, ctx) in &known {
-                    per_provider.insert(id.clone(), *ctx);
-                }
+            let mut cache = self.model_contexts.write().await;
+            let per_provider = cache.entry(provider_id.to_string()).or_default();
+            for (id, ctx) in &known {
+                per_provider.insert(id.clone(), *ctx);
             }
-            let mut updated = false;
-            {
-                let mut cfg = self.config.write().await;
-                if let Some(p) = cfg.providers.get_mut(provider_id) {
-                    for m in p.models.iter_mut() {
-                        if let Some(vision_models) = &vision_models {
-                            let next = vision_models.contains(&m.id);
-                            if m.supports_vision != next {
-                                m.supports_vision = next;
-                                updated = true;
-                            }
+        }
+        let mut updated = false;
+        {
+            let mut cfg = self.config.write().await;
+            if let Some(p) = cfg.providers.get_mut(provider_id) {
+                for m in p.models.iter_mut() {
+                    if let Some(protocol) = detected_protocols.get(&m.id) {
+                        if m.protocol.as_ref() != Some(protocol) {
+                            m.protocol = Some(protocol.clone());
+                            updated = true;
                         }
-                        if m.context_window.is_none() {
-                            if let Some((_, ctx)) = known.iter().find(|(id, _)| id == &m.id) {
-                                m.context_window = Some(*ctx);
-                                updated = true;
-                            }
+                    }
+                    if let Some(vision_models) = &vision_models {
+                        let next = vision_models.contains(&m.id);
+                        if m.supports_vision != next {
+                            m.supports_vision = next;
+                            updated = true;
+                        }
+                    }
+                    if m.context_window.is_none() {
+                        if let Some((_, ctx)) = known.iter().find(|(id, _)| id == &m.id) {
+                            m.context_window = Some(*ctx);
+                            updated = true;
                         }
                     }
                 }
             }
-            if updated {
-                self.persist().await?;
-                self.maybe_auto_apply().await;
-            }
+        }
+        if updated {
+            self.persist().await?;
+            self.maybe_auto_apply().await;
         }
         Ok(detailed.into_iter().map(|(id, _)| id).collect())
     }
@@ -943,6 +999,143 @@ fn entry_context_window(m: &serde_json::Value) -> Option<u32> {
         .and_then(|v| u32::try_from(v).ok())
 }
 
+/// Build a deliberately tiny non-streaming request for one upstream wire.
+/// A successful status proves the gateway accepted both this model and this
+/// endpoint shape; model discovery itself only returns ids, never this fact.
+fn dialect_probe_request(
+    protocol: &crate::config::ProviderProtocol,
+    model: &str,
+) -> (&'static str, serde_json::Value) {
+    use crate::config::ProviderProtocol;
+    match protocol {
+        ProviderProtocol::OpenAI => (
+            "chat/completions",
+            serde_json::json!({
+                "model": model,
+                "messages": [{"role": "user", "content": "Reply with OK."}],
+                "max_tokens": 16,
+                "stream": false,
+            }),
+        ),
+        ProviderProtocol::Anthropic => (
+            "messages",
+            serde_json::json!({
+                "model": model,
+                "messages": [{"role": "user", "content": "Reply with OK."}],
+                "max_tokens": 16,
+                "stream": false,
+            }),
+        ),
+        ProviderProtocol::Responses => (
+            "responses",
+            serde_json::json!({
+                "model": model,
+                "input": "Reply with OK.",
+                "max_output_tokens": 16,
+                "stream": false,
+            }),
+        ),
+    }
+}
+
+const MAX_PARALLEL_DIALECT_PROBES: usize = 3;
+
+async fn probe_enabled_model_dialects(
+    provider: &crate::config::Provider,
+    provider_id: &str,
+    model_ids: Vec<String>,
+) -> std::collections::HashMap<String, crate::config::ProviderProtocol> {
+    use futures::stream::{self, StreamExt};
+
+    stream::iter(model_ids.into_iter().map(|id| {
+        let provider = provider.clone();
+        let provider_id = provider_id.to_string();
+        async move {
+            let protocol = probe_model_dialect(&provider, &id).await;
+            (provider_id, id, protocol)
+        }
+    }))
+    // Gateways can rate-limit bursts, so lower the wall-clock wait without
+    // turning a long enabled-model list into an unbounded request fan-out.
+    .buffer_unordered(MAX_PARALLEL_DIALECT_PROBES)
+    .filter_map(|(provider_id, id, result)| async move {
+        match result {
+            Ok(protocol) => Some((id, protocol)),
+            Err(error) => {
+                tracing::warn!(
+                    provider = %provider_id,
+                    model = %id,
+                    "model dialect validation failed: {error}"
+                );
+                None
+            }
+        }
+    })
+    .collect()
+    .await
+}
+
+fn select_detected_dialect(
+    provider_default: crate::config::ProviderProtocol,
+    supported: &[crate::config::ProviderProtocol],
+) -> Option<crate::config::ProviderProtocol> {
+    supported
+        .iter()
+        .find(|protocol| **protocol == provider_default)
+        .cloned()
+        .or_else(|| supported.first().cloned())
+}
+
+async fn probe_model_dialect(
+    provider: &crate::config::Provider,
+    model: &str,
+) -> anyhow::Result<crate::config::ProviderProtocol> {
+    use crate::config::ProviderProtocol;
+
+    // This provider executes through the local CLI, not an HTTP endpoint.
+    if provider.id == crate::providers::CLAUDE_CODE_PROVIDER_ID {
+        return Ok(ProviderProtocol::Anthropic);
+    }
+
+    let client = http_client();
+    let candidates = [
+        ProviderProtocol::OpenAI,
+        ProviderProtocol::Anthropic,
+        ProviderProtocol::Responses,
+    ];
+    let mut supported = Vec::new();
+    for protocol in candidates {
+        let (path, body) = dialect_probe_request(&protocol, model);
+        let mut probe_provider = provider.clone();
+        probe_provider.protocol = protocol.clone();
+        let url = format!("{}/{path}", provider.base_url.trim_end_matches('/'));
+        let mut request =
+            crate::proxy::apply_provider_auth(client.post(url).json(&body), &probe_provider, None);
+        if let Some(user_agent) = &provider.user_agent {
+            request = request.header("user-agent", user_agent);
+        }
+        match request.send().await {
+            Ok(response) if response.status().is_success() => supported.push(protocol),
+            Ok(response) => tracing::debug!(
+                provider = %provider.id,
+                model,
+                protocol = ?protocol,
+                status = %response.status(),
+                "model dialect probe rejected"
+            ),
+            Err(error) => tracing::debug!(
+                provider = %provider.id,
+                model,
+                protocol = ?protocol,
+                "model dialect probe failed: {error}"
+            ),
+        }
+    }
+    select_detected_dialect(provider.protocol.clone(), &supported).ok_or_else(|| {
+        anyhow::anyhow!("no supported upstream wire dialect detected for model '{model}'")
+    })
+}
+
 /// Fetch a provider's live model catalog, keeping whatever context window
 /// each entry publishes. Most providers publish none — OpenCode Go returns
 /// only id/created/object/owned_by, which is what the models.dev
@@ -983,7 +1176,7 @@ pub async fn list_models_detailed(
             .unwrap_or("unknown error");
         anyhow::bail!("provider returned {status}: {msg}");
     }
-    let models = body
+    let models: Vec<_> = body
         .get("data")
         .and_then(serde_json::Value::as_array)
         .map(|arr| {
@@ -996,7 +1189,10 @@ pub async fn list_models_detailed(
                 .collect()
         })
         .unwrap_or_default();
-    Ok(models)
+    Ok(models
+        .into_iter()
+        .filter(|(id, _)| !crate::config::is_gpt_model_id(id))
+        .collect())
 }
 
 /// Fetch a provider's live model catalog (also validates the API key).
@@ -1106,5 +1302,79 @@ mod tests {
         // The kimi-coding preset is published by models.dev under its
         // canonical catalog name, not the CLI-facing slug.
         assert_eq!(models_dev_key("kimi-coding"), "kimi-for-coding");
+    }
+
+    #[test]
+    fn dialect_probe_requests_use_each_wire_format() {
+        let (path, chat) =
+            dialect_probe_request(&crate::config::ProviderProtocol::OpenAI, "kimi-k3");
+        assert_eq!(path, "chat/completions");
+        assert_eq!(chat["model"], "kimi-k3");
+        assert_eq!(chat["messages"][0]["content"], "Reply with OK.");
+
+        let (path, anthropic) =
+            dialect_probe_request(&crate::config::ProviderProtocol::Anthropic, "qwen3.8-max");
+        assert_eq!(path, "messages");
+        assert_eq!(anthropic["model"], "qwen3.8-max");
+        assert_eq!(anthropic["max_tokens"], 16);
+
+        let (path, responses) =
+            dialect_probe_request(&crate::config::ProviderProtocol::Responses, "gpt-5.6-sol");
+        assert_eq!(path, "responses");
+        assert_eq!(responses["model"], "gpt-5.6-sol");
+        assert_eq!(responses["input"], "Reply with OK.");
+    }
+
+    #[test]
+    fn detected_dialect_prefers_the_provider_default_when_several_work() {
+        use crate::config::ProviderProtocol;
+
+        let detected = select_detected_dialect(
+            ProviderProtocol::Responses,
+            &[ProviderProtocol::OpenAI, ProviderProtocol::Responses],
+        );
+
+        assert_eq!(detected, Some(ProviderProtocol::Responses));
+    }
+
+    #[tokio::test]
+    async fn startup_catalog_repair_regenerates_an_enabled_integration() {
+        // This catches a regression where startup notices the integration but
+        // leaves its generated model catalog stale. A newly shipped native
+        // model then cannot reach Codex's picker until the user clicks Apply.
+        let config = AppConfig {
+            codex_integration: true,
+            port: 4242,
+            ..AppConfig::default()
+        };
+        let state = state_with_config(config);
+        let regenerated = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let observed = regenerated.clone();
+
+        let repaired = state
+            .repair_codex_integration_with(move |config, port| {
+                assert!(config.codex_integration);
+                assert_eq!(port, 4242);
+                observed.store(true, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        assert!(repaired);
+        assert!(regenerated.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn startup_catalog_repair_leaves_disabled_integration_untouched() {
+        let state = state_with_config(AppConfig::default());
+        let repaired = state
+            .repair_codex_integration_with(|_, _| -> anyhow::Result<()> {
+                panic!("disabled integrations must not rewrite Codex configuration")
+            })
+            .await
+            .unwrap();
+
+        assert!(!repaired);
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,7 +27,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": true,
+    "createUpdaterArtifacts": false,
     "macOS": {
       "signingIdentity": "-"
     },

--- a/src-tauri/tauri.release.conf.json
+++ b/src-tauri/tauri.release.conf.json
@@ -1,0 +1,5 @@
+{
+  "bundle": {
+    "createUpdaterArtifacts": true
+  }
+}

--- a/src-tauri/tests/e2e.rs
+++ b/src-tauri/tests/e2e.rs
@@ -180,6 +180,71 @@ async fn responses_non_stream_end_to_end() {
 }
 
 #[tokio::test]
+async fn responses_accepts_compaction_payload_above_default_axum_limit() {
+    let upstream_app = Router::new().route(
+        "/v1/chat/completions",
+        post(|_body: axum::body::Bytes| async {
+            axum::Json(serde_json::json!({
+                "id": "chatcmpl-large",
+                "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+            }))
+        }),
+    ).layer(axum::extract::DefaultBodyLimit::max(16 * 1024 * 1024));
+    let upstream_url = spawn(upstream_app).await;
+
+    let mut providers = BTreeMap::new();
+    providers.insert(
+        "test".to_string(),
+        Provider {
+            id: "test".into(),
+            name: "Test".into(),
+            protocol: ProviderProtocol::OpenAI,
+            base_url: format!("{upstream_url}/v1"),
+            api_key: Some("sk-test".into()),
+            has_key: true,
+            context_window: None,
+            user_agent: None,
+            models: vec![ProviderModel {
+                id: "m".into(),
+                label: None,
+                context_window: None,
+                protocol: None,
+                fast_mode: false,
+                enabled: true,
+                supports_vision: false,
+            }],
+            enabled: true,
+        },
+    );
+    let proxy_url = spawn(proxy::router(
+        Arc::new(RwLock::new(AppConfig {
+            port: 0,
+            providers,
+            ..AppConfig::default()
+        })),
+        Arc::new(RwLock::new(Stats::in_memory())),
+    ))
+    .await;
+
+    let large_input = "x".repeat(3 * 1024 * 1024);
+    let resp = reqwest::Client::new()
+        .post(format!("{proxy_url}/v1/responses"))
+        .header("x-loomrouter-token", proxy::local_token())
+        .json(&serde_json::json!({
+            "model": "test/m",
+            "input": large_input,
+            "stream": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert!(status.is_success(), "unexpected response: {status} {body}");
+}
+
+#[tokio::test]
 async fn responses_websocket_end_to_end() {
     use futures::{SinkExt, StreamExt};
     use tokio_tungstenite::tungstenite::Message;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -94,7 +94,7 @@ const en = {
     protocol: 'Protocol',
     modelDialect: 'Wire dialect',
     modelDialectHint:
-      'This gateway serves several dialects. Pick the one it uses for this model — the wrong one is rejected upstream.',
+      'Detected automatically with a short upstream validation request when the model is fetched or enabled.',
     vision: 'Vision',
     visionSupport: 'Vision support for {{model}}',
     providerEnabled: 'Provider enabled',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -93,7 +93,7 @@ const es: DeepPartial<Strings> = {
     protocol: 'Protocolo',
     modelDialect: 'Dialecto',
     modelDialectHint:
-      'Esta pasarela atiende en varios dialectos. Elige el que usa para este modelo — el equivocado se rechaza del otro lado.',
+      'Se detecta automáticamente con una solicitud corta de validación al buscar o activar el modelo.',
     fastMode: 'Modo rápido',
     claudePlan: 'Plan {{plan}}',
     claudeLoggedIn: 'Claude Code inició sesión',

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -92,7 +92,7 @@ const pt: DeepPartial<Strings> = {
     protocol: 'Protocolo',
     modelDialect: 'Dialeto',
     modelDialectHint:
-      'Este gateway atende em vários dialetos. Escolha o que ele usa para este modelo — o errado é recusado do outro lado.',
+      'Detectado automaticamente com uma requisição curta de validação ao buscar ou ativar o modelo.',
     fastMode: 'Modo rápido',
     claudePlan: 'Plano {{plan}}',
     claudeLoggedIn: 'Claude Code conectado',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -94,7 +94,7 @@ const zh: DeepPartial<Strings> = {
     keyRequired: '请先输入 API 密钥。',
     protocol: '协议',
     modelDialect: '接口方言',
-    modelDialectHint: '该网关同时提供多种方言。请选择它为此模型使用的那一种——选错会被上游拒绝。',
+    modelDialectHint: '获取或启用模型时，会通过一次简短的上游验证请求自动检测。',
     fastMode: '快速模式',
     claudePlan: '{{plan}} 套餐',
     claudeLoggedIn: 'Claude Code 已登录',

--- a/src/pages/Codex.tsx
+++ b/src/pages/Codex.tsx
@@ -280,13 +280,13 @@ function VisualAssistanceCard({
         </Select>
 
         <div className="space-y-2">
-          <div className="flex gap-2">
+          <div className="flex flex-col gap-2">
             <Select
               value={fallbackCandidate}
               onValueChange={setFallbackCandidate}
               disabled={busy || !config || !assistance.enabled || fallbackOptions.length === 0}
             >
-              <SelectTrigger aria-label={s.codex.visualAssistanceFallback}>
+              <SelectTrigger className="w-full" aria-label={s.codex.visualAssistanceFallback}>
                 <SelectValue placeholder={s.codex.visualAssistanceFallbackPlaceholder} />
               </SelectTrigger>
               <SelectContent>
@@ -300,6 +300,7 @@ function VisualAssistanceCard({
             </Select>
             <Button
               variant="outline"
+              className="w-full"
               onClick={() => void addFallback()}
               disabled={busy || !assistance.enabled || fallbackCandidate === OFF_SENTINEL}
             >

--- a/src/pages/Providers.tsx
+++ b/src/pages/Providers.tsx
@@ -361,42 +361,24 @@ function dialectsInUse(provider: Provider): ProviderProtocol[] {
   return PROTOCOLS.filter((p) => seen.has(p))
 }
 
-/// Per-model dialect picker, shown only on providers that serve more than
-/// one. Everywhere else the provider's protocol is the whole story and a
-/// control per model would be noise.
-function DialectPicker({
+/// The protocol is detected by a real upstream probe when models are fetched
+/// or enabled. Show the result, not a choice the user cannot verify.
+function DetectedDialect({
   provider,
   model,
-  onChanged,
 }: {
   provider: Provider
   model: { id: string; protocol?: ProviderProtocol | null }
-  onChanged: () => void
 }) {
   const s = useStrings()
   return (
-    <Select
-      value={model.protocol ?? provider.protocol}
-      onValueChange={async (value) => {
-        await api.setModelProtocol(provider.id, model.id, value as ProviderProtocol)
-        onChanged()
-      }}
+    <Badge
+      variant="outline"
+      className="shrink-0 px-2 py-0 text-xs font-normal"
+      title={s.providers.modelDialectHint}
     >
-      <SelectTrigger
-        className="h-6 w-28 shrink-0 text-xs"
-        aria-label={s.providers.modelDialect}
-        title={s.providers.modelDialectHint}
-      >
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        {PROTOCOLS.map((p) => (
-          <SelectItem key={p} value={p}>
-            {p}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+      {model.protocol ?? provider.protocol}
+    </Badge>
   )
 }
 
@@ -602,7 +584,7 @@ const ProviderCard = memo(function ProviderCard({
               )}
               <ContextWindowTag info={windows?.[`${provider.id}/${m.id}`]} />
               {multiDialect && (
-                <DialectPicker provider={provider} model={m} onChanged={onChanged} />
+                <DetectedDialect provider={provider} model={m} />
               )}
             </label>
           ))}


### PR DESCRIPTION
## What changed, and why

<!--
Lead with the behaviour a user would notice, then the reason. If this fixes
something broken, describe the shape of the failure — that context is what
stops the bug from being reintroduced, and it belongs in the commit and at the
fix site too, not only here. See CONTRIBUTING.md, "Record the bug in the fix".
-->

Fixes #

## How it was verified

<!--
Name the check that would have failed before this change. "Tests pass" is not
that — CI already says so. Something like "added
`normalize_usage_reads_kimi_per_choice_placement`, which fails on main" is.
For provider-facing changes, say which provider and which endpoint you
actually ran against.
-->

## Checklist

- [ ] The full gate passes locally, not just the part I touched:
      `bun run lint && bun run test && bun run build`, and
      `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
      `cargo test` (all three with `--manifest-path src-tauri/Cargo.toml`)
- [ ] Tests live beside the code and are named as the sentence they assert
- [ ] No request or response body is logged — they carry user prompts and
      source code. Metadata only: path, status, byte length
- [ ] No provider field name is read outside `translate.rs`
- [ ] If this changes a Tauri command's backend state, the browser mock in
      `src/lib/api.ts` changed with it and is complete against its TS type
- [ ] If this is a version bump: `package.json`, `src-tauri/tauri.conf.json`
      and `src-tauri/Cargo.toml` all moved together, and `CHANGELOG.md` has
      the matching `## x.y.z` section in this same commit

<!--
First PR here? The gate is strict on purpose and every rule in CONTRIBUTING.md
exists because breaking it already cost this project a bug. If a check fails
for a reason you can't place, say so in a comment rather than forcing it —
`rustfmt` output differs between toolchain releases, and a local toolchain
older than CI's is the usual culprit.
-->
