### PR TITLE
fix(proxy): stream claude-code turns and answer response.cancel

### DIFF
--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -377,10 +377,31 @@ pub fn stream_print_turn(
     let failure = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<bytes::Bytes>();
     let fail_slot = failure.clone();
-    let stdout = child.stdout.take();
+
+    // Kills the CLI and removes the temp settings file on every early-exit
+    // path. Dropping a Child does neither, so without this guard a cancelled
+    // turn would leave `claude -p` running tools in the workspace.
+    struct ChildGuard {
+        child: Option<std::process::Child>,
+        injected: std::path::PathBuf,
+    }
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            if let Some(ref mut child) = self.child {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            let _ = std::fs::remove_file(&self.injected);
+        }
+    }
+    let mut guard = ChildGuard {
+        child: Some(child),
+        injected: injected.clone(),
+    };
+
     std::thread::spawn(move || {
         let mut state = StreamTurn::new(&id, &model);
-        if let Some(stdout) = stdout {
+        if let Some(stdout) = guard.child.as_mut().and_then(|c| c.stdout.take()) {
             for line in BufReader::new(stdout).lines().map_while(Result::ok) {
                 if line.trim().is_empty() {
                     continue;
@@ -395,8 +416,11 @@ pub fn stream_print_turn(
                 }
             }
         }
-        let status = child.wait();
-        let _ = std::fs::remove_file(&injected);
+        // Normal exit: the child ran to completion, so wait for its
+        // exit status. Defuse the guard so it doesn't kill the
+        // already-finished process or re-remove the temp file.
+        let status = guard.child.take().unwrap().wait();
+        drop(guard);
         let stderr = stderr_buf
             .lock()
             .unwrap_or_else(|e| e.into_inner())

--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -9,6 +9,7 @@
 //! Nothing here calls the Anthropic API directly and no token is read from
 //! disk, so this stays on the safe side of Anthropic's credential policy.
 
+use futures::StreamExt;
 use serde::Serialize;
 use serde_json::{json, Value};
 
@@ -271,6 +272,329 @@ fn claude_project_dir() -> Option<std::path::PathBuf> {
         .join("settings.json")
         .is_file()
         .then_some(cwd)
+}
+
+/// One turn's input to the CLI: a flat prompt, or Claude Code's stream-json
+/// message protocol when the turn carries images.
+pub enum ClaudeTurnInput {
+    Text(String),
+    StreamJson(String),
+}
+
+/// Anthropic SSE frames as the CLI produces them, plus the slot a failure
+/// lands in once the frames run out.
+pub type StreamedTurn = (
+    futures::stream::BoxStream<'static, Result<bytes::Bytes, reqwest::Error>>,
+    std::sync::Arc<std::sync::Mutex<Option<String>>>,
+);
+
+/// Run one turn and emit Anthropic SSE frames **as the CLI produces them**.
+///
+/// `run_print_turn` waits for the whole agentic run before emitting anything.
+/// `claude -p` is not a single completion — it is a full agent loop that can
+/// work for many minutes, so that silence is indistinguishable from a hang.
+/// Worse, clients treat a silent stream as a dead one: Codex drops it after
+/// 300s with "stream disconnected" and retries, which restarts the run from
+/// scratch, so a turn longer than the timeout can never converge.
+///
+/// Emitting frames as they arrive keeps the stream demonstrably alive and
+/// shows the work. The frames are the same Anthropic SSE shape
+/// `anthropic_sse_stream` builds, so the existing translator consumes them
+/// unchanged — only their arrival is spread over the run.
+///
+/// The three pipes are drained by separate threads on purpose. A single
+/// thread that writes all of stdin before reading stdout deadlocks once the
+/// prompt outgrows the 64KB pipe buffer and the child blocks writing output
+/// nobody is reading yet — a latent hang for exactly the large prompts this
+/// change targets.
+///
+/// Errors cannot ride the byte stream (its error type is `reqwest::Error`,
+/// which this module cannot mint), so a failure lands in the returned slot
+/// and the caller appends it once the frames run out.
+pub fn stream_print_turn(
+    input: ClaudeTurnInput,
+    model: &str,
+    id: &str,
+    config_dir: Option<&std::path::Path>,
+) -> anyhow::Result<StreamedTurn> {
+    use std::io::{BufRead, BufReader, Write};
+
+    let Some(bin) = claude_binary() else {
+        anyhow::bail!("claude CLI not found (set CLAUDE_BIN to its location)");
+    };
+    let injected = injected_claude_settings()?;
+    let model = model.to_string();
+    let id = id.to_string();
+    let config_dir = config_dir.map(std::path::Path::to_path_buf);
+
+    let mut cmd = std::process::Command::new(&bin);
+    crate::cli_locator::hide_console_window(&mut cmd);
+    if let Some(dir) = claude_project_dir() {
+        cmd.current_dir(dir);
+    }
+    cmd.arg("-p").arg("--model").arg(&model);
+    cmd.arg("--settings").arg(&injected);
+    if matches!(input, ClaudeTurnInput::StreamJson(_)) {
+        cmd.arg("--input-format").arg("stream-json");
+    }
+    cmd.arg("--output-format")
+        .arg("stream-json")
+        .arg("--verbose")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .env("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
+        .env("CLAUDE_CODE_SKIP_BACKGROUND_PREFETCH", "1");
+    if let Some(dir) = config_dir {
+        cmd.env("CLAUDE_CONFIG_DIR", dir);
+    }
+
+    let mut child = cmd.spawn()?;
+    let payload = match input {
+        ClaudeTurnInput::Text(t) => t,
+        ClaudeTurnInput::StreamJson(t) => t,
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        std::thread::spawn(move || {
+            let _ = stdin.write_all(payload.as_bytes());
+        });
+    }
+    // Drained so a chatty CLI can never block on a full stderr pipe.
+    let stderr_buf = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+    if let Some(stderr) = child.stderr.take() {
+        let sink = stderr_buf.clone();
+        std::thread::spawn(move || {
+            for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+                let mut guard = sink.lock().unwrap_or_else(|e| e.into_inner());
+                if guard.len() < 8192 {
+                    guard.push_str(&line);
+                    guard.push('\n');
+                }
+            }
+        });
+    }
+
+    let failure = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<bytes::Bytes>();
+    let fail_slot = failure.clone();
+    let stdout = child.stdout.take();
+    std::thread::spawn(move || {
+        let mut state = StreamTurn::new(&id, &model);
+        if let Some(stdout) = stdout {
+            for line in BufReader::new(stdout).lines().map_while(Result::ok) {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let Ok(event) = serde_json::from_str::<Value>(&line) else {
+                    continue;
+                };
+                for frame in state.on_cli_event(&event) {
+                    if tx.send(bytes::Bytes::from(frame)).is_err() {
+                        return; // client hung up
+                    }
+                }
+            }
+        }
+        let status = child.wait();
+        let _ = std::fs::remove_file(&injected);
+        let stderr = stderr_buf
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .trim()
+            .chars()
+            .take(500)
+            .collect::<String>();
+        let failed = match &status {
+            Ok(s) if !s.success() => Some(format!("`claude -p` exited {s}: {stderr}")),
+            Err(e) => Some(format!("`claude -p` could not be waited on: {e}")),
+            _ => state.error.clone(),
+        };
+        match failed {
+            Some(message) => {
+                *fail_slot.lock().unwrap_or_else(|e| e.into_inner()) = Some(message);
+            }
+            None => {
+                for frame in state.finish() {
+                    if tx.send(bytes::Bytes::from(frame)).is_err() {
+                        return;
+                    }
+                }
+            }
+        }
+    });
+
+    let stream = futures::stream::unfold(rx, |mut rx| async move {
+        rx.recv().await.map(|chunk| (Ok(chunk), rx))
+    })
+    .boxed();
+    Ok((stream, failure))
+}
+
+/// Turns Claude Code's `stream-json` lines into Anthropic SSE frames.
+///
+/// The CLI reports whole assistant messages rather than token deltas, so each
+/// one becomes a text delta. `message_start` is held back until the first has
+/// arrived, because that is when its `input_tokens` are known and the
+/// translator reads them from nowhere else.
+struct StreamTurn {
+    id: String,
+    model: String,
+    opened: bool,
+    streamed_text: bool,
+    input_tokens: u64,
+    output_tokens: u64,
+    result_text: String,
+    error: Option<String>,
+}
+
+impl StreamTurn {
+    fn new(id: &str, model: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            model: model.to_string(),
+            opened: false,
+            streamed_text: false,
+            input_tokens: 0,
+            output_tokens: 0,
+            result_text: String::new(),
+            error: None,
+        }
+    }
+
+    fn open(&mut self, out: &mut Vec<String>) {
+        if self.opened {
+            return;
+        }
+        self.opened = true;
+        out.push(anthropic_sse_event(
+            "message_start",
+            &json!({
+                "type": "message_start",
+                "message": {
+                    "id": self.id,
+                    "type": "message",
+                    "role": "assistant",
+                    "model": self.model,
+                    "content": [],
+                    "usage": {"input_tokens": self.input_tokens, "output_tokens": 0},
+                },
+            }),
+        ));
+        out.push(anthropic_sse_event(
+            "content_block_start",
+            &json!({
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "text", "text": ""},
+            }),
+        ));
+    }
+
+    fn on_cli_event(&mut self, event: &Value) -> Vec<String> {
+        let mut out = Vec::new();
+        match event.get("type").and_then(Value::as_str) {
+            Some("assistant") => {
+                if let Some(usage) = event.pointer("/message/usage") {
+                    if let Some(n) = usage.get("input_tokens").and_then(Value::as_u64) {
+                        if self.input_tokens == 0 {
+                            self.input_tokens = n;
+                        }
+                    }
+                }
+                let blocks = event
+                    .pointer("/message/content")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                for block in blocks {
+                    if block.get("type").and_then(Value::as_str) != Some("text") {
+                        continue;
+                    }
+                    let text = block.get("text").and_then(Value::as_str).unwrap_or("");
+                    if text.is_empty() {
+                        continue;
+                    }
+                    self.open(&mut out);
+                    self.streamed_text = true;
+                    out.push(anthropic_sse_event(
+                        "content_block_delta",
+                        &json!({
+                            "type": "content_block_delta",
+                            "index": 0,
+                            "delta": {"type": "text_delta", "text": text},
+                        }),
+                    ));
+                }
+            }
+            Some("result") => {
+                if event.get("is_error").and_then(Value::as_bool) == Some(true) {
+                    self.error = Some(format!(
+                        "`claude -p` returned an error: {}",
+                        event.get("result").and_then(Value::as_str).unwrap_or("")
+                    ));
+                    return out;
+                }
+                self.result_text = event
+                    .get("result")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                if let Some(usage) = event.get("usage") {
+                    if let Some(n) = usage.get("input_tokens").and_then(Value::as_u64) {
+                        if self.input_tokens == 0 {
+                            self.input_tokens = n;
+                        }
+                    }
+                    self.output_tokens = usage
+                        .get("output_tokens")
+                        .and_then(Value::as_u64)
+                        .unwrap_or(0);
+                }
+            }
+            _ => {}
+        }
+        out
+    }
+
+    /// Closing frames. A run that reported no assistant text still has to
+    /// deliver the `result` line's answer, or the turn arrives empty.
+    fn finish(&mut self) -> Vec<String> {
+        let mut out = Vec::new();
+        self.open(&mut out);
+        if !self.streamed_text && !self.result_text.is_empty() {
+            let text = std::mem::take(&mut self.result_text);
+            out.push(anthropic_sse_event(
+                "content_block_delta",
+                &json!({
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": text},
+                }),
+            ));
+        }
+        out.push(anthropic_sse_event(
+            "content_block_stop",
+            &json!({"type": "content_block_stop", "index": 0}),
+        ));
+        out.push(anthropic_sse_event(
+            "message_delta",
+            &json!({
+                "type": "message_delta",
+                "delta": {"stop_reason": "end_turn"},
+                // input_tokens ride along because message_start was emitted
+                // before the CLI reported them on short runs.
+                "usage": {
+                    "input_tokens": self.input_tokens,
+                    "output_tokens": self.output_tokens,
+                },
+            }),
+        ));
+        out.push(anthropic_sse_event(
+            "message_stop",
+            &json!({"type": "message_stop"}),
+        ));
+        out
+    }
 }
 
 /// Run one non-interactive turn through the local `claude` CLI.

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -907,7 +907,24 @@ async fn run_claude_turn(
     upstream_model: &str,
     wire: WireApi,
 ) -> anyhow::Result<(crate::claude_cli::ClaudePrintResult, String)> {
-    let messages = match wire {
+    let messages = claude_turn_messages(payload, upstream_model, wire)?;
+    let messages = messages.as_array().map(Vec::as_slice).unwrap_or_default();
+    let result = if crate::claude_cli::messages_have_images(messages) {
+        crate::claude_cli::run_print_turn_stream_json(messages, upstream_model, None).await?
+    } else {
+        let prompt = crate::claude_cli::render_prompt(messages);
+        crate::claude_cli::run_print_turn(&prompt, upstream_model, None).await?
+    };
+    Ok((result, claude_turn_id()))
+}
+
+/// The transcript one turn feeds to the CLI, in either wire's shape.
+fn claude_turn_messages(
+    payload: &Value,
+    upstream_model: &str,
+    wire: WireApi,
+) -> anyhow::Result<Value> {
+    Ok(match wire {
         WireApi::Responses => {
             let chat = translate::responses_to_chat(payload, upstream_model, false)?;
             chat.get("messages")
@@ -918,22 +935,37 @@ async fn run_claude_turn(
             .get("messages")
             .cloned()
             .unwrap_or_else(|| Value::Array(Vec::new())),
-    };
-    let messages = messages.as_array().map(Vec::as_slice).unwrap_or_default();
-    let result = if crate::claude_cli::messages_have_images(messages) {
-        crate::claude_cli::run_print_turn_stream_json(messages, upstream_model, None).await?
-    } else {
-        let prompt = crate::claude_cli::render_prompt(messages);
-        crate::claude_cli::run_print_turn(&prompt, upstream_model, None).await?
-    };
-    let id = format!(
+    })
+}
+
+fn claude_turn_id() -> String {
+    format!(
         "msg_cli_{}",
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_millis())
             .unwrap_or(0)
-    );
-    Ok((result, id))
+    )
+}
+
+/// Prepare one turn's CLI input without running it, for the streaming bridge.
+/// Picks the same protocol `run_claude_turn` would: stream-json carries image
+/// blocks, a flat prompt covers everything else.
+fn claude_turn_input(
+    payload: &Value,
+    upstream_model: &str,
+    wire: WireApi,
+) -> anyhow::Result<(crate::claude_cli::ClaudeTurnInput, String)> {
+    let messages = claude_turn_messages(payload, upstream_model, wire)?;
+    let messages = messages.as_array().map(Vec::as_slice).unwrap_or_default();
+    let input = if crate::claude_cli::messages_have_images(messages) {
+        crate::claude_cli::ClaudeTurnInput::StreamJson(crate::claude_cli::render_stream_json(
+            messages,
+        )?)
+    } else {
+        crate::claude_cli::ClaudeTurnInput::Text(crate::claude_cli::render_prompt(messages))
+    };
+    Ok((input, claude_turn_id()))
 }
 
 fn sanitize_responses_payload(payload: &mut Value) {

--- a/src-tauri/src/proxy/realtime.rs
+++ b/src-tauri/src/proxy/realtime.rs
@@ -490,7 +490,7 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
     // the turn loop) is parked here so the next iteration still handles it.
     let mut pending: Option<Message> = None;
 
-    loop {
+    'session: loop {
         let msg = match pending.take() {
             Some(msg) => msg,
             None => match rx.next().await {
@@ -613,94 +613,128 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
         let mut output_items: Vec<Value> = Vec::new();
         let mut completed_response_id: Option<String> = None;
 
-        match ws_turn_events(&ctx, &headers, payload).await {
-            Ok((mut events, final_provider, key_id)) => {
-                let mut cancelled = false;
-                loop {
-                    let item = tokio::select! {
-                        // Upstream events win a tie: a cancel racing with
-                        // already-produced output never discards that output.
-                        biased;
-                        item = events.next() => match item {
-                            Some(item) => item,
-                            None => break,
-                        },
-                        // Only polled while nothing is parked, so a queued
-                        // frame can never be overwritten by the next one.
-                        incoming = rx.next(), if pending.is_none() => match incoming {
-                            Some(Ok(Message::Text(t))) => {
-                                if is_cancel_frame(&t) {
-                                    cancelled = true;
-                                    break;
-                                }
-                                pending = Some(Message::Text(t));
-                                continue;
-                            }
-                            Some(Ok(_)) => continue,
-                            // Client hung up mid-turn.
-                            _ => return,
-                        },
-                    };
-                    let frame = match &item {
-                        Ok(v) => v.clone(),
-                        Err(e) => ws_error_frame(502, e),
-                    };
-                    if let Ok(v) = &item {
-                        match v.get("type").and_then(Value::as_str) {
-                            Some("response.output_item.done") => {
-                                if let Some(it) = v.get("item") {
-                                    output_items.push(it.clone());
-                                }
-                            }
-                            Some("response.completed") => {
-                                completed_response_id = v
-                                    .pointer("/response/id")
-                                    .and_then(Value::as_str)
-                                    .map(str::to_string);
-                                // Canonical Responses frames on this transport.
-                                record_payload_usage(
-                                    &ctx.stats,
-                                    &Turn::new(&final_provider, &model, "ws", Some(turn_start))
-                                        .with_key(key_id.as_deref()),
-                                    UpstreamKind::Responses,
-                                    v,
-                                    visual_assistance.as_ref(),
-                                );
-                            }
-                            _ => {}
+        // Race stream setup against cancellation so a cancel frame is
+        // not ignored while visual assistance, upstream headers, or CLI
+        // startup are still in progress. The previous implementation awaited
+        // ws_turn_events before first polling the socket.
+        //
+        // The future is pinned outside the loop so payload's borrow does not
+        // need to be re-created on every loop iteration.
+        let turn_fut = ws_turn_events(&ctx, &headers, payload);
+        tokio::pin!(turn_fut);
+        let (mut events, final_provider, key_id) = loop {
+            tokio::select! {
+                result = &mut turn_fut => {
+                    match result {
+                        Ok(v) => break v,
+                        Err((e, final_provider, key_id)) => {
+                            record_failure(
+                                &ctx.stats,
+                                &Turn::new(&final_provider, &model, "ws", Some(turn_start))
+                                    .with_key(key_id.as_deref()),
+                                &e.to_string(),
+                            );
+                            let frame = ws_error_frame(502, &e.to_string());
+                            let _ = tx.send(Message::Text(frame.to_string().into())).await;
+                            continue 'session;
                         }
                     }
-                    let done =
-                        frame.get("type").and_then(Value::as_str) == Some("response.completed");
-                    if tx
-                        .send(Message::Text(frame.to_string().into()))
-                        .await
-                        .is_err()
-                    {
-                        return;
-                    }
-                    if done {
-                        break;
-                    }
                 }
-                if cancelled {
-                    // The client closes its turn state only on a terminal
-                    // frame. Without one it waits forever and every later
-                    // prompt on the session looks like it is still thinking.
-                    let _ = tx
-                        .send(Message::Text(ws_cancelled_frame().to_string().into()))
-                        .await;
+                incoming = rx.next() => {
+                    match incoming {
+                        Some(Ok(Message::Text(t))) if is_cancel_frame(&t) => {
+                            let _ = tx
+                                .send(Message::Text(
+                                    ws_cancelled_frame().to_string().into(),
+                                ))
+                                .await;
+                            continue 'session;
+                        }
+                        Some(Ok(msg)) => {
+                            // Non-cancel frame during setup: buffer it and
+                            // keep waiting for turn initialization.
+                            pending = Some(msg);
+                        }
+                        _ => return,
+                    }
                 }
             }
-            Err((e, final_provider, key_id)) => {
-                record_failure(
-                    &ctx.stats,
-                    &Turn::new(&final_provider, &model, "ws", Some(turn_start))
-                        .with_key(key_id.as_deref()),
-                    &e.to_string(),
-                );
-                let frame = ws_error_frame(502, &e.to_string());
-                let _ = tx.send(Message::Text(frame.to_string().into())).await;
+        };
+        {
+            let mut cancelled = false;
+            loop {
+                let item = tokio::select! {
+                    // Upstream events win a tie: a cancel racing with
+                    // already-produced output never discards that output.
+                    biased;
+                    item = events.next() => match item {
+                        Some(item) => item,
+                        None => break,
+                    },
+                    // Only polled while nothing is parked, so a queued
+                    // frame can never be overwritten by the next one.
+                    incoming = rx.next(), if pending.is_none() => match incoming {
+                        Some(Ok(Message::Text(t))) => {
+                            if is_cancel_frame(&t) {
+                                cancelled = true;
+                                break;
+                            }
+                            pending = Some(Message::Text(t));
+                            continue;
+                        }
+                        Some(Ok(_)) => continue,
+                        // Client hung up mid-turn.
+                        _ => return,
+                    },
+                };
+                let frame = match &item {
+                    Ok(v) => v.clone(),
+                    Err(e) => ws_error_frame(502, e),
+                };
+                if let Ok(v) = &item {
+                    match v.get("type").and_then(Value::as_str) {
+                        Some("response.output_item.done") => {
+                            if let Some(it) = v.get("item") {
+                                output_items.push(it.clone());
+                            }
+                        }
+                        Some("response.completed") => {
+                            completed_response_id = v
+                                .pointer("/response/id")
+                                .and_then(Value::as_str)
+                                .map(str::to_string);
+                            // Canonical Responses frames on this transport.
+                            record_payload_usage(
+                                &ctx.stats,
+                                &Turn::new(&final_provider, &model, "ws", Some(turn_start))
+                                    .with_key(key_id.as_deref()),
+                                UpstreamKind::Responses,
+                                v,
+                                visual_assistance.as_ref(),
+                            );
+                        }
+                        _ => {}
+                    }
+                }
+                let done = frame.get("type").and_then(Value::as_str) == Some("response.completed");
+                if tx
+                    .send(Message::Text(frame.to_string().into()))
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                if done {
+                    break;
+                }
+            }
+            if cancelled {
+                // The client closes its turn state only on a terminal
+                // frame. Without one it waits forever and every later
+                // prompt on the session looks like it is still thinking.
+                let _ = tx
+                    .send(Message::Text(ws_cancelled_frame().to_string().into()))
+                    .await;
             }
         }
 
@@ -957,18 +991,37 @@ async fn ws_claude_cli_events(
         translate::tool_namespace_map(payload),
         translate::freeform_tool_names(payload),
     ));
-    // A CLI failure cannot ride the byte stream, so it is appended once the
-    // frames run out (see `stream_print_turn`).
-    let tail =
-        futures::stream::once(
-            async move { failure.lock().unwrap_or_else(|e| e.into_inner()).take() },
-        )
-        .filter_map(|failed| async move { failed.map(Err) });
-    Ok(with_keepalive(
-        sse_values_stream(bytes, translator).chain(tail).boxed(),
-        WS_KEEPALIVE,
+    // A CLI failure cannot ride the byte stream, so the failure slot is
+    // checked when the translated stream produces `response.completed`. If
+    // the slot is populated, the completed frame is replaced with an error
+    // and the stream stops — otherwise the failure would be appended after
+    // the terminal event and the WS loop would never poll it.
+    let inner = sse_values_stream(bytes, translator).boxed();
+    let checked = futures::stream::unfold(
+        (inner, failure, false),
+        |(mut inner, failure, mut sent)| async move {
+            if sent {
+                return None;
+            }
+            match inner.next().await {
+                Some(Ok(ref v))
+                    if v.get("type").and_then(Value::as_str) == Some("response.completed") =>
+                {
+                    let fail = failure.lock().unwrap_or_else(|e| e.into_inner()).take();
+                    if let Some(msg) = fail {
+                        sent = true;
+                        Some((Err(format!("claude: {msg}")), (inner, failure, sent)))
+                    } else {
+                        Some((Ok(v.clone()), (inner, failure, sent)))
+                    }
+                }
+                Some(item) => Some((item, (inner, failure, sent))),
+                None => None,
+            }
+        },
     )
-    .boxed())
+    .boxed();
+    Ok(with_keepalive(checked, WS_KEEPALIVE).boxed())
 }
 
 /// How long a turn may go without producing an event before a `ping` is sent.

--- a/src-tauri/src/proxy/realtime.rs
+++ b/src-tauri/src/proxy/realtime.rs
@@ -486,9 +486,18 @@ pub(super) fn replace_incremental_input(payload: &mut Value, input: Vec<Value>) 
 
 async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
     let (mut tx, mut rx) = socket.split();
+    // A non-cancel frame read while a turn is streaming (see the select! in
+    // the turn loop) is parked here so the next iteration still handles it.
+    let mut pending: Option<Message> = None;
 
-    while let Some(msg) = rx.next().await {
-        let Ok(msg) = msg else { break };
+    loop {
+        let msg = match pending.take() {
+            Some(msg) => msg,
+            None => match rx.next().await {
+                Some(Ok(msg)) => msg,
+                _ => break,
+            },
+        };
         let text = match msg {
             Message::Text(t) => t,
             Message::Close(_) => break,
@@ -505,7 +514,8 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
                     m.remove("type");
                 }
             }
-            // Best effort: in-flight turns are not interrupted.
+            // An in-flight turn is cancelled inside the turn loop below, so a
+            // cancel arriving here has nothing left to stop.
             Some("response.cancel") => continue,
             _ => continue,
         }
@@ -605,7 +615,32 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
 
         match ws_turn_events(&ctx, &headers, payload).await {
             Ok((mut events, final_provider, key_id)) => {
-                while let Some(item) = events.next().await {
+                let mut cancelled = false;
+                loop {
+                    let item = tokio::select! {
+                        // Upstream events win a tie: a cancel racing with
+                        // already-produced output never discards that output.
+                        biased;
+                        item = events.next() => match item {
+                            Some(item) => item,
+                            None => break,
+                        },
+                        // Only polled while nothing is parked, so a queued
+                        // frame can never be overwritten by the next one.
+                        incoming = rx.next(), if pending.is_none() => match incoming {
+                            Some(Ok(Message::Text(t))) => {
+                                if is_cancel_frame(&t) {
+                                    cancelled = true;
+                                    break;
+                                }
+                                pending = Some(Message::Text(t));
+                                continue;
+                            }
+                            Some(Ok(_)) => continue,
+                            // Client hung up mid-turn.
+                            _ => return,
+                        },
+                    };
                     let frame = match &item {
                         Ok(v) => v.clone(),
                         Err(e) => ws_error_frame(502, e),
@@ -648,6 +683,14 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
                         break;
                     }
                 }
+                if cancelled {
+                    // The client closes its turn state only on a terminal
+                    // frame. Without one it waits forever and every later
+                    // prompt on the session looks like it is still thinking.
+                    let _ = tx
+                        .send(Message::Text(ws_cancelled_frame().to_string().into()))
+                        .await;
+                }
             }
             Err((e, final_provider, key_id)) => {
                 record_failure(
@@ -675,6 +718,31 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
                 .insert(rid, record, prev.as_deref());
         }
     }
+}
+
+/// Whether a client frame asks to stop the turn in flight.
+fn is_cancel_frame(text: &str) -> bool {
+    serde_json::from_str::<Value>(text)
+        .ok()
+        .and_then(|v| {
+            v.get("type")
+                .and_then(Value::as_str)
+                .map(|t| t == "response.cancel")
+        })
+        .unwrap_or(false)
+}
+
+/// Terminal frame for a cancelled turn. `response.incomplete` is the Responses
+/// API's own "stopped before finishing" event, so clients already treat it as
+/// terminal; a bespoke type would leave them waiting just like no frame at all.
+fn ws_cancelled_frame() -> Value {
+    json!({
+        "type": "response.incomplete",
+        "response": {
+            "status": "incomplete",
+            "incomplete_details": {"reason": "cancelled"},
+        },
+    })
 }
 
 fn ws_error_frame(status: u16, message: &str) -> Value {

--- a/src-tauri/src/proxy/realtime.rs
+++ b/src-tauri/src/proxy/realtime.rs
@@ -949,23 +949,48 @@ async fn ws_claude_cli_events(
             ),
         );
     }
-    let (result, id) = run_claude_turn(payload, upstream_model, WireApi::Responses).await?;
-    let frames = crate::claude_cli::anthropic_sse_stream(
-        &id,
-        upstream_model,
-        &result.text,
-        result.input_tokens,
-        result.output_tokens,
-    );
-    let bytes: Vec<Bytes> = frames.into_iter().map(Bytes::from).collect();
+    let (input, id) = super::claude_turn_input(payload, upstream_model, WireApi::Responses)?;
+    let (bytes, failure) = crate::claude_cli::stream_print_turn(input, upstream_model, &id, None)?;
     let translator = Some((
         UpstreamKind::Anthropic,
         model.to_string(),
         translate::tool_namespace_map(payload),
         translate::freeform_tool_names(payload),
     ));
-    Ok(sse_values_stream(
-        futures::stream::iter(bytes.into_iter().map(Ok::<_, reqwest::Error>)).boxed(),
-        translator,
-    ))
+    // A CLI failure cannot ride the byte stream, so it is appended once the
+    // frames run out (see `stream_print_turn`).
+    let tail =
+        futures::stream::once(
+            async move { failure.lock().unwrap_or_else(|e| e.into_inner()).take() },
+        )
+        .filter_map(|failed| async move { failed.map(Err) });
+    Ok(with_keepalive(
+        sse_values_stream(bytes, translator).chain(tail).boxed(),
+        WS_KEEPALIVE,
+    )
+    .boxed())
+}
+
+/// How long a turn may go without producing an event before a `ping` is sent.
+///
+/// Codex drops a stream it considers idle after 300s and retries, which for a
+/// `claude -p` turn restarts the whole agent run, so a turn slower than the
+/// timeout could never finish. Streaming already breaks most silences, but the
+/// gap while the agent runs a long tool has nothing to send, so the stream says
+/// so itself. Well under the client's limit, and `ping` is the event routed
+/// providers already emit for this.
+const WS_KEEPALIVE: std::time::Duration = std::time::Duration::from_secs(20);
+
+pub(super) fn with_keepalive(
+    inner: futures::stream::BoxStream<'static, Result<Value, String>>,
+    every: std::time::Duration,
+) -> impl futures::Stream<Item = Result<Value, String>> {
+    futures::stream::unfold(Some(inner), move |state| async move {
+        let mut inner = state?;
+        match tokio::time::timeout(every, inner.next()).await {
+            Ok(Some(item)) => Some((item, Some(inner))),
+            Ok(None) => None,
+            Err(_) => Some((Ok(json!({"type": "ping"})), Some(inner))),
+        }
+    })
 }

--- a/src-tauri/src/proxy/tests_realtime.rs
+++ b/src-tauri/src/proxy/tests_realtime.rs
@@ -438,3 +438,51 @@ fn two_large_conversations_coexist_without_evicting_each_other() {
     );
     assert_eq!(history.order.len(), 2);
 }
+
+/// A turn that goes quiet must still put frames on the wire.
+///
+/// Codex drops a stream it considers idle after 300s and retries, which for a
+/// `claude -p` turn restarts the whole agent run — so a silent gap while the
+/// agent works a long tool is what makes a slow turn unable to ever finish.
+#[tokio::test]
+async fn ut_060_keepalive_pings_a_silent_turn_and_keeps_real_events() {
+    use futures::StreamExt;
+
+    // One event, then a gap far longer than the keepalive, then the terminal.
+    let inner = futures::stream::unfold(0u8, |step| async move {
+        match step {
+            0 => Some((Ok(json!({"type": "response.created"})), 1)),
+            1 => {
+                tokio::time::sleep(std::time::Duration::from_millis(260)).await;
+                Some((Ok(json!({"type": "response.completed"})), 2))
+            }
+            _ => None,
+        }
+    })
+    .boxed();
+
+    let seen: Vec<Value> =
+        super::realtime::with_keepalive(inner, std::time::Duration::from_millis(50))
+            .map(|item| item.expect("no errors in this stream"))
+            .collect()
+            .await;
+
+    let kinds: Vec<&str> = seen
+        .iter()
+        .filter_map(|v| v.get("type").and_then(Value::as_str))
+        .collect();
+    assert!(
+        kinds.contains(&"ping"),
+        "a silent stretch produced no keepalive: {kinds:?}"
+    );
+    assert_eq!(
+        kinds.first().copied(),
+        Some("response.created"),
+        "real events must not be reordered behind pings: {kinds:?}"
+    );
+    assert_eq!(
+        kinds.last().copied(),
+        Some("response.completed"),
+        "the terminal event must still close the stream: {kinds:?}"
+    );
+}

--- a/src-tauri/src/translate/stream.rs
+++ b/src-tauri/src/translate/stream.rs
@@ -359,6 +359,20 @@ impl StreamTranslator {
                     let existing = self.usage.take().unwrap_or(json!({}));
                     let mut merged = existing;
                     merged["output_tokens"] = u.get("output_tokens").cloned().unwrap_or(json!(0));
+                    // Anthropic itself only reports input_tokens on
+                    // message_start. A streamed `claude -p` turn does not know
+                    // them yet at that point, so honour them here when sent —
+                    // otherwise the turn records zero prompt tokens.
+                    if let Some(input) = u.get("input_tokens") {
+                        if merged
+                            .get("input_tokens")
+                            .and_then(Value::as_u64)
+                            .unwrap_or(0)
+                            == 0
+                        {
+                            merged["input_tokens"] = input.clone();
+                        }
+                    }
                     self.usage = Some(merged);
                 }
                 if data.pointer("/delta/stop_reason").is_some() {

--- a/src-tauri/tests/claude_stream.rs
+++ b/src-tauri/tests/claude_stream.rs
@@ -1,0 +1,152 @@
+//! The claude-code bridge must emit frames while the CLI works, not after it
+//! finishes.
+//!
+//! Its own test binary on purpose: `claude_binary()` memoises the resolved
+//! path in a `OnceLock`, so `CLAUDE_BIN` only takes effect in a process that
+//! has not resolved it yet — and only for the first path it sees. Everything
+//! therefore runs as one sequential test against one script whose behaviour is
+//! switched through a mode file.
+
+use futures::StreamExt;
+use loom_router_lib::claude_cli::{stream_print_turn, ClaudeTurnInput};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+struct FakeCli {
+    dir: PathBuf,
+}
+
+impl FakeCli {
+    /// A stand-in `claude`. `slow` answers in two instalments with a gap
+    /// between them, the way a real agent run interleaves output with tool
+    /// work; `fast` does the same without the waits; `fail` exits non-zero.
+    fn install() -> Self {
+        let dir = std::env::temp_dir().join(format!("loom-claude-stream-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let script = dir.join("fake-claude.sh");
+        let assistant_one = r#"{"type":"assistant","message":{"usage":{"input_tokens":11},"content":[{"type":"text","text":"first "}]}}"#;
+        let assistant_two =
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"second"}]}}"#;
+        let result = r#"{"type":"result","subtype":"success","result":"first second","session_id":"s1","usage":{"input_tokens":11,"output_tokens":7}}"#;
+        let body = format!(
+            r#"#!/bin/sh
+cat > /dev/null
+mode=$(cat "{dir}/mode")
+if [ "$mode" = "fail" ]; then
+  echo boom >&2
+  exit 3
+fi
+gap=0
+[ "$mode" = "slow" ] && gap=1
+printf '%s\n' '{assistant_one}'
+sleep $gap
+printf '%s\n' '{assistant_two}'
+sleep $gap
+printf '%s\n' '{result}'
+"#,
+            dir = dir.display(),
+        );
+        std::fs::write(&script, body).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&script).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&script, perms).unwrap();
+        }
+        std::env::set_var("CLAUDE_BIN", &script);
+        Self { dir }
+    }
+
+    fn mode(&self, mode: &str) {
+        std::fs::write(self.dir.join("mode"), mode).unwrap();
+    }
+
+    fn path(&self) -> &Path {
+        &self.dir
+    }
+}
+
+/// Run one turn, returning every frame with the moment it arrived.
+async fn run_turn() -> (Vec<(Duration, String)>, Option<String>) {
+    let started = Instant::now();
+    let (mut bytes, failure) = stream_print_turn(
+        ClaudeTurnInput::Text("hi".to_string()),
+        "claude-opus-5",
+        "msg_test",
+        None,
+    )
+    .expect("spawning the fake CLI");
+
+    let mut seen = Vec::new();
+    while let Some(chunk) = bytes.next().await {
+        let chunk = chunk.expect("byte stream never yields Err");
+        seen.push((
+            started.elapsed(),
+            String::from_utf8_lossy(&chunk).to_string(),
+        ));
+    }
+    let failed = failure.lock().unwrap().clone();
+    (seen, failed)
+}
+
+#[tokio::test]
+async fn claude_cli_turns_stream_while_they_run() {
+    let cli = FakeCli::install();
+    assert!(cli.path().is_dir());
+
+    // 1. Frames must arrive DURING the run, not bunched at the end.
+    cli.mode("slow");
+    let (seen, failed) = run_turn().await;
+    assert!(failed.is_none(), "a clean run must not record a failure");
+
+    let first_text = seen
+        .iter()
+        .find(|(_, frame)| frame.contains("\"text_delta\""))
+        .map(|(at, _)| *at)
+        .expect("no text delta was ever emitted");
+    let last = seen.last().map(|(at, _)| *at).expect("no frames at all");
+
+    // The fake CLI runs for ~2s. Before the fix nothing was emitted until it
+    // exited, so the first delta landed together with the last frame.
+    assert!(
+        first_text < Duration::from_millis(1500),
+        "first text delta arrived at {first_text:?}: nothing streamed while the CLI worked"
+    );
+    assert!(
+        last - first_text > Duration::from_millis(500),
+        "every frame arrived at once ({first_text:?} -> {last:?}): the run was not streamed"
+    );
+
+    // 2. Content and usage must survive the incremental path.
+    cli.mode("fast");
+    let (seen, failed) = run_turn().await;
+    assert!(failed.is_none(), "a clean run must not record a failure");
+    let whole: String = seen.into_iter().map(|(_, frame)| frame).collect();
+
+    assert!(whole.contains("first "), "missing the first instalment");
+    assert!(whole.contains("second"), "missing the second instalment");
+    assert_eq!(
+        whole.matches("second").count(),
+        1,
+        "the trailing result line re-sent text already streamed:\n{whole}"
+    );
+    assert!(
+        whole.contains("\"input_tokens\":11"),
+        "prompt tokens must survive into the frames:\n{whole}"
+    );
+    assert!(
+        whole.contains("\"output_tokens\":7"),
+        "completion tokens must survive into the frames:\n{whole}"
+    );
+    assert!(whole.contains("message_stop"), "turn never terminated");
+
+    // 3. A failing CLI must be reported, not swallowed into an empty turn.
+    cli.mode("fail");
+    let (_, failed) = run_turn().await;
+    let failed = failed.expect("a non-zero exit must be reported");
+    assert!(
+        failed.contains("boom"),
+        "the failure must carry the CLI's stderr: {failed}"
+    );
+}

--- a/src-tauri/tests/claude_stream.rs
+++ b/src-tauri/tests/claude_stream.rs
@@ -23,13 +23,34 @@ impl FakeCli {
     fn install() -> Self {
         let dir = std::env::temp_dir().join(format!("loom-claude-stream-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
-        let script = dir.join("fake-claude.sh");
-        let assistant_one = r#"{"type":"assistant","message":{"usage":{"input_tokens":11},"content":[{"type":"text","text":"first "}]}}"#;
-        let assistant_two =
-            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"second"}]}}"#;
-        let result = r#"{"type":"result","subtype":"success","result":"first second","session_id":"s1","usage":{"input_tokens":11,"output_tokens":7}}"#;
-        let body = format!(
-            r#"#!/bin/sh
+        let script = install_fake_cli(&dir);
+        std::env::set_var("CLAUDE_BIN", &script);
+        Self { dir }
+    }
+
+    fn mode(&self, mode: &str) {
+        std::fs::write(self.dir.join("mode"), mode).unwrap();
+    }
+
+    fn path(&self) -> &Path {
+        &self.dir
+    }
+}
+
+/// A stand-in `claude` implemented as a /bin/sh script. Slow answers in two
+/// instalments with a gap between them, mirroring a real agent run; fast does
+/// the same without waits; fail exits non-zero.
+#[cfg(unix)]
+fn install_fake_cli(dir: &std::path::Path) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let script = dir.join("fake-claude.sh");
+    let assistant_one = r#"{"type":"assistant","message":{"usage":{"input_tokens":11},"content":[{"type":"text","text":"first "}]}}"#;
+    let assistant_two =
+        r#"{"type":"assistant","message":{"content":[{"type":"text","text":"second"}]}}"#;
+    let result = r#"{"type":"result","subtype":"success","result":"first second","session_id":"s1","usage":{"input_tokens":11,"output_tokens":7}}"#;
+    let body = format!(
+        r#"#!/bin/sh
 cat > /dev/null
 mode=$(cat "{dir}/mode")
 if [ "$mode" = "fail" ]; then
@@ -44,29 +65,49 @@ printf '%s\n' '{assistant_two}'
 sleep $gap
 printf '%s\n' '{result}'
 "#,
-            dir = dir.display(),
-        );
-        std::fs::write(&script, body).unwrap();
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let mut perms = std::fs::metadata(&script).unwrap().permissions();
-            perms.set_mode(0o755);
-            std::fs::set_permissions(&script, perms).unwrap();
-        }
-        std::env::set_var("CLAUDE_BIN", &script);
-        Self { dir }
-    }
-
-    fn mode(&self, mode: &str) {
-        std::fs::write(self.dir.join("mode"), mode).unwrap();
-    }
-
-    fn path(&self) -> &Path {
-        &self.dir
-    }
+        dir = dir.display(),
+    );
+    std::fs::write(&script, body).unwrap();
+    let mut perms = std::fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).unwrap();
+    script
 }
 
+/// A stand-in `claude` implemented as a Windows batch script. Same three
+/// modes as the Unix helper: slow answers with delays, fast answers
+/// immediately, fail exits non-zero. `timeout /t` replaces `sleep` (minimum
+/// 1s, close enough to the Unix sleep 1).
+#[cfg(windows)]
+fn install_fake_cli(dir: &std::path::Path) -> std::path::PathBuf {
+    let script = dir.join("fake-claude.cmd");
+    let assistant_one = r#"{"type":"assistant","message":{"usage":{"input_tokens":11},"content":[{"type":"text","text":"first "}]}}"#;
+    let assistant_two =
+        r#"{"type":"assistant","message":{"content":[{"type":"text","text":"second"}]}}"#;
+    let result = r#"{"type":"result","subtype":"success","result":"first second","session_id":"s1","usage":{"input_tokens":11,"output_tokens":7}}"#;
+    // echo( is the most robust batch echo form: it handles leading {, }, and
+    // quoted strings without interpreting them as redirection or grouping.
+    let body = format!(
+        r#"@echo off
+set /p _dummy=
+set /p mode=<"{dir}\mode"
+if "%mode%"=="fail" (
+  echo boom 1>&2
+  exit /b 3
+)
+set gap=0
+if "%mode%"=="slow" set gap=1
+echo({assistant_one}
+timeout /t %gap% /nobreak > nul
+echo({assistant_two}
+timeout /t %gap% /nobreak > nul
+echo({result}
+"#,
+        dir = dir.display(),
+    );
+    std::fs::write(&script, body).unwrap();
+    script
+}
 /// Run one turn, returning every frame with the moment it arrived.
 async fn run_turn() -> (Vec<(Duration, String)>, Option<String>) {
     let started = Instant::now();

--- a/src-tauri/tests/e2e/responses_ws.rs
+++ b/src-tauri/tests/e2e/responses_ws.rs
@@ -518,3 +518,142 @@ async fn ws_native_turn_then_routed_switch_clamps_with_anchored_summary() {
         "recent tail must survive the clamp:\n{whole}"
     );
 }
+
+/// Regression: a `response.cancel` sent while a turn is streaming must end the
+/// turn with a terminal frame, and must leave the session usable.
+///
+/// Before the fix the cancel was never even read (the turn was awaited inline,
+/// so the read loop was not polling) and was then dropped by a catch-all arm.
+/// The client got no terminal event, so its turn state stayed open and every
+/// later prompt on that connection looked like it was still thinking.
+#[tokio::test]
+async fn ws_cancel_ends_the_turn_and_keeps_the_session_usable() {
+    // First turn stalls after one chunk; any later turn answers normally, so
+    // the second turn proves the session survived the cancel.
+    let calls = Arc::new(Mutex::new(0usize));
+    let seen = calls.clone();
+    let upstream_app = Router::new().route(
+        "/v1/chat/completions",
+        post(move || {
+            let seen = seen.clone();
+            async move {
+                let nth = {
+                    let mut g = seen.lock().unwrap();
+                    *g += 1;
+                    *g
+                };
+                let body = if nth == 1 {
+                    let head = futures::stream::once(async {
+                        Ok::<_, std::io::Error>(axum::body::Bytes::from(
+                            "data: {\"id\":\"c1\",\"choices\":[{\"delta\":{\"content\":\"thinking\"},\"finish_reason\":null}]}\n\n",
+                        ))
+                    });
+                    // Never completes within the test's lifetime.
+                    let stall = futures::stream::once(async {
+                        tokio::time::sleep(std::time::Duration::from_secs(600)).await;
+                        Ok(axum::body::Bytes::from("data: [DONE]\n\n"))
+                    });
+                    axum::body::Body::from_stream(head.chain(stall))
+                } else {
+                    axum::body::Body::from(UPSTREAM_SSE.to_string())
+                };
+                axum::response::Response::builder()
+                    .header("content-type", "text/event-stream")
+                    .body(body)
+                    .unwrap()
+            }
+        }),
+    );
+    let upstream_url = spawn(upstream_app).await;
+
+    let mut providers = BTreeMap::new();
+    providers.insert(
+        "test".to_string(),
+        provider(
+            "test",
+            "Test",
+            ProviderProtocol::OpenAI,
+            format!("{upstream_url}/v1"),
+            "sk-test",
+            "m",
+            None,
+        ),
+    );
+    let proxy_url = spawn_proxy(AppConfig {
+        port: 0,
+        providers,
+        ..AppConfig::default()
+    })
+    .await;
+    let (mut ws, _resp) = tokio_tungstenite::connect_async(&ws_url(&proxy_url))
+        .await
+        .unwrap();
+
+    let create = |text: &str| {
+        Message::Text(
+            serde_json::json!({
+                "type": "response.create",
+                "model": "test/m",
+                "input": [{"role":"user","content":[{"type":"input_text","text":text}]}],
+            })
+            .to_string()
+            .into(),
+        )
+    };
+
+    // Turn 1: wait until it is genuinely mid-stream before cancelling.
+    ws.send(create("hi")).await.unwrap();
+    let wait_for_delta = async {
+        while let Some(Ok(Message::Text(frame))) = ws.next().await {
+            let event: serde_json::Value = serde_json::from_str(&frame).unwrap();
+            if event["type"] == "response.output_text.delta" {
+                return;
+            }
+        }
+        panic!("stream ended before any delta");
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(10), wait_for_delta)
+        .await
+        .expect("upstream never produced the first delta");
+
+    ws.send(Message::Text(
+        serde_json::json!({"type": "response.cancel"}).to_string().into(),
+    ))
+    .await
+    .unwrap();
+
+    // The cancel must produce a terminal frame; the upstream is still stalled,
+    // so anything that arrives can only have come from the cancel path.
+    let wait_for_terminal = async {
+        while let Some(Ok(Message::Text(frame))) = ws.next().await {
+            let event: serde_json::Value = serde_json::from_str(&frame).unwrap();
+            if event["type"] == "response.incomplete" {
+                return event;
+            }
+        }
+        panic!("socket closed without a terminal frame");
+    };
+    let terminal = tokio::time::timeout(std::time::Duration::from_secs(10), wait_for_terminal)
+        .await
+        .expect("cancel produced no terminal frame: the client would hang forever");
+    assert_eq!(
+        terminal["response"]["incomplete_details"]["reason"], "cancelled",
+        "terminal frame must say why the turn stopped:\n{terminal}"
+    );
+
+    // Turn 2 on the SAME connection must work.
+    ws.send(create("again")).await.unwrap();
+    let wait_for_completed = async {
+        while let Some(Ok(Message::Text(frame))) = ws.next().await {
+            let event: serde_json::Value = serde_json::from_str(&frame).unwrap();
+            if event["type"] == "response.completed" {
+                return;
+            }
+        }
+        panic!("socket closed before the second turn completed");
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(15), wait_for_completed)
+        .await
+        .expect("session was poisoned by the cancel: the next turn never completed");
+    ws.close(None).await.unwrap();
+}

--- a/src-tauri/tests/e2e/responses_ws.rs
+++ b/src-tauri/tests/e2e/responses_ws.rs
@@ -617,7 +617,9 @@ async fn ws_cancel_ends_the_turn_and_keeps_the_session_usable() {
         .expect("upstream never produced the first delta");
 
     ws.send(Message::Text(
-        serde_json::json!({"type": "response.cancel"}).to_string().into(),
+        serde_json::json!({"type": "response.cancel"})
+            .to_string()
+            .into(),
     ))
     .await
     .unwrap();


### PR DESCRIPTION
## Problem

Every agent routed through LoomRouter would eventually sit "thinking" forever, across all providers, with **nothing logged in `loom.db`** and **no upstream connection** to show for it.

The cause is in `ws_session`. A turn was awaited inline with no `tokio::spawn`, so the read loop was not polling while a turn streamed:

1. A `response.cancel` sent mid-turn was not read until the turn finished.
2. It was then dropped by the catch-all arm (`Some("response.cancel") => continue`), whose comment conceded *"Best effort: in-flight turns are not interrupted."*
3. The client received no terminal event, so its turn state never closed.

From then on the connection was dead: every later prompt on it looked like it was still thinking. Because all agents share one WS session, they all appeared to break at once — it is per-connection, not per-provider.

Observed in the wild: a turn started at 12:17:07, the user hit interrupt at 12:20:11, and the session never served another request while the socket stayed ESTABLISHED and the proxy sat at 0% CPU.

## Fix

- Stream the turn under `tokio::select!` so client frames are read while it runs.
- Answer a cancel with `response.incomplete` and `incomplete_details.reason = "cancelled"` — the Responses API's own terminal event, which clients already treat as closing a turn. A bespoke type would leave them waiting just like no frame at all.
- `biased;` keeps upstream events winning a tie, so a cancel racing with already-produced output never discards it.
- A non-cancel frame arriving mid-turn is parked in `pending` and handled on the next iteration rather than dropped. The select guard (`if pending.is_none()`) stops a parked frame from being overwritten — otherwise this would trade a lost-cancel bug for a lost-turn bug.

## Test

`ws_cancel_ends_the_turn_and_keeps_the_session_usable` — upstream stalls after the first chunk, the client cancels mid-stream, and a second turn on the **same** connection must still complete.

Confirmed it fails without the fix:

```
cancel produced no terminal frame: the client would hang forever: Elapsed(())
```

`cargo test`: 394 passed. `cargo clippy --all-targets`: clean.

## Note

This fixes the bug found in the code, and the evidence points to it. It was never possible to test the hypothesis against the live wedged session, because that session's client process had not actually restarted — closing the window on macOS left the `app-server` helper running. A genuine restart is what unblocked the reporter.