### PR TITLE
fix(proxy): support large Codex compaction payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Written for the person installing the build. Internal churn is left out.
 
+## 0.2.9
+
+### Fixed
+
+- **Automatic compaction no longer fails with HTTP 413 on large Codex chats.**
+  Responses and compaction requests now accept transcripts up to 128 MiB by
+  default, with a configurable limit for unusually large sessions and a 1 GiB
+  hard ceiling against accidental local memory exhaustion. The larger limit is
+  restricted to `/v1/responses` and `/v1/responses/compact`; ordinary chat
+  completions keep their existing 16 MiB limit.
+
 ## 0.2.8
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loom-router",
   "private": true,
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2250,7 +2250,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom-router"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "loom-router"
 # Kept in lockstep with package.json and tauri.conf.json; the release
 # workflow verifies all three against the tag.
-version = "0.2.8"
+version = "0.2.9"
 description = "Weave any model into your coding agent's picker."
 authors = ["LoomRouter contributors"]
 license = "MIT"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -6,6 +6,23 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+/// Default decompressed request-body ceiling for the local proxy, in bytes.
+///
+/// Codex automatic compaction replays the full conversation through
+/// `/v1/responses`, so the ceiling must comfortably exceed a large context
+/// window after JSON encoding and any provider-side expansion. 128 MiB keeps
+/// the common case well under one allocation while leaving headroom for long
+/// tool transcripts.
+pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 128 * 1024 * 1024;
+
+/// Hard upper bound for `max_request_body_bytes`.
+///
+/// The proxy only listens on 127.0.0.1 behind a local token, so this is not
+/// a security boundary against untrusted networks. It exists to stop a
+/// mistyped config or environment override from turning one local request
+/// into an unbounded in-memory buffer.
+pub const MAX_REQUEST_BODY_BYTES_HARD_LIMIT: usize = 1024 * 1024 * 1024;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[derive(Default)]
@@ -180,6 +197,11 @@ pub struct AppConfig {
     /// Proxy listen port on 127.0.0.1.
     #[serde(default = "default_port")]
     pub port: u16,
+    /// Maximum decompressed JSON body size accepted by the local proxy, in
+    /// bytes. Applies to the Codex Responses and remote-compaction routes,
+    /// whose payloads are the only ones expected to grow with context.
+    #[serde(default = "default_max_request_body_bytes")]
+    pub max_request_body_bytes: usize,
     #[serde(default)]
     pub providers: BTreeMap<String, Provider>,
     /// Whether the Codex integration is active. When true, any config
@@ -243,10 +265,15 @@ fn default_port() -> u16 {
     4180
 }
 
+fn default_max_request_body_bytes() -> usize {
+    DEFAULT_MAX_REQUEST_BODY_BYTES
+}
+
 impl Default for AppConfig {
     fn default() -> Self {
         Self {
             port: default_port(),
+            max_request_body_bytes: default_max_request_body_bytes(),
             providers: BTreeMap::new(),
             codex_integration: false,
             side_call_fallback: None,

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -7,7 +7,9 @@
 //!   POST /v1/chat/completions — OpenAI-compatible clients
 //!   GET  /health              — liveness for the UI
 
-use crate::config::{AppConfig, Provider};
+use crate::config::{
+    AppConfig, Provider, DEFAULT_MAX_REQUEST_BODY_BYTES, MAX_REQUEST_BODY_BYTES_HARD_LIMIT,
+};
 use crate::keypool::KeyPools;
 use crate::sse::{frame_data, frame_done, frame_with_event, SseParser};
 use crate::state::SharedConfig;
@@ -73,9 +75,42 @@ use upstream::{build_upstream, needs_responses_function_tool_compat, send};
 
 type EffectiveRoute = RoutePlan;
 
-// Codex remote compaction can legitimately carry a multi-megabyte transcript.
-// Keep a finite bound while exceeding Axum's 2 MiB default for `Bytes`.
-const MAX_REQUEST_BODY_BYTES: usize = 16 * 1024 * 1024;
+/// Environment override for [`resolve_max_request_body_bytes`]. Useful for
+/// users with an unusually large Codex transcript who do not want to edit
+/// `config.json` or wait for the next config-aware server start.
+const MAX_REQUEST_BODY_BYTES_ENV: &str = "LOOM_ROUTER_MAX_REQUEST_BODY_BYTES";
+
+/// Body ceiling for OpenAI-compatible `/v1/chat/completions` requests.
+///
+/// These requests do not replay a Codex conversation, so they keep the
+/// previous 16 MiB bound instead of inheriting the larger compaction limit.
+const CHAT_COMPLETIONS_MAX_REQUEST_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+/// Resolve the per-route body limit for Codex Responses and compaction.
+///
+/// A fixed 16 MiB limit turned out to be too small for real automatic
+/// compaction payloads, which can carry a full multi-megabyte transcript
+/// after JSON encoding and decompression. The default is deliberately
+/// generous and is bounded by a hard ceiling so a bad config or environment
+/// value cannot create an unbounded local allocation.
+fn resolve_max_request_body_bytes(config: &SharedConfig) -> usize {
+    let configured = config
+        .try_read()
+        .map(|cfg| cfg.max_request_body_bytes)
+        .unwrap_or(DEFAULT_MAX_REQUEST_BODY_BYTES);
+    let env = std::env::var(MAX_REQUEST_BODY_BYTES_ENV).ok();
+    resolve_max_request_body_bytes_value(configured, env.as_deref())
+}
+
+fn resolve_max_request_body_bytes_value(configured: usize, env: Option<&str>) -> usize {
+    let from_env = env.and_then(|raw| raw.trim().parse::<usize>().ok());
+    let value = from_env.unwrap_or(configured);
+    if value == 0 {
+        DEFAULT_MAX_REQUEST_BODY_BYTES
+    } else {
+        value.min(MAX_REQUEST_BODY_BYTES_HARD_LIMIT)
+    }
+}
 
 #[derive(Clone)]
 struct ProxyCtx {
@@ -132,6 +167,7 @@ pub fn router_with_pools(config: SharedConfig, stats: SharedStats, key_pools: Ke
     // Materialize the local token at startup so the first request never
     // pays (or races) initialization.
     let _ = local_token();
+    let max_responses_body_bytes = resolve_max_request_body_bytes(&config);
     let ctx = ProxyCtx {
         config,
         stats,
@@ -147,16 +183,25 @@ pub fn router_with_pools(config: SharedConfig, stats: SharedStats, key_pools: Ke
         .route("/v1/models", get(handle_models))
         .route(
             "/v1/responses",
-            get(handle_responses_ws).post(handle_responses),
+            get(handle_responses_ws)
+                .post(handle_responses)
+                .layer(DefaultBodyLimit::max(max_responses_body_bytes)),
         )
-        .route("/v1/responses/compact", post(handle_compact))
-        .route("/v1/chat/completions", post(handle_chat_completions))
+        .route(
+            "/v1/responses/compact",
+            post(handle_compact).layer(DefaultBodyLimit::max(max_responses_body_bytes)),
+        )
+        .route(
+            "/v1/chat/completions",
+            post(handle_chat_completions).layer(DefaultBodyLimit::max(
+                CHAT_COMPLETIONS_MAX_REQUEST_BODY_BYTES,
+            )),
+        )
         .fallback(log_unmatched)
         .with_state(ctx)
         // The Codex App sends request bodies compressed (gzip/br/zstd).
         // Decompress transparently before handlers see the bytes.
         .layer(tower_http::decompression::RequestDecompressionLayer::new())
-        .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_BYTES))
         // Every route (including /health and the WS upgrade) requires the
         // local token; see `auth_gate`.
         .layer(middleware::from_fn(auth_gate))
@@ -1085,5 +1130,42 @@ fn sanitize_stateless_responses_payload(payload: &mut Value) {
             _ => 2,
         });
         start = end;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_limit_zero_means_generous_default() {
+        assert_eq!(
+            resolve_max_request_body_bytes_value(0, None),
+            DEFAULT_MAX_REQUEST_BODY_BYTES
+        );
+    }
+
+    #[test]
+    fn body_limit_honors_configured_value_and_clamps_hard_ceiling() {
+        assert_eq!(
+            resolve_max_request_body_bytes_value(1024 * 1024, None),
+            1024 * 1024
+        );
+        assert_eq!(
+            resolve_max_request_body_bytes_value(MAX_REQUEST_BODY_BYTES_HARD_LIMIT + 1, None),
+            MAX_REQUEST_BODY_BYTES_HARD_LIMIT
+        );
+    }
+
+    #[test]
+    fn body_limit_env_override_wins_and_invalid_env_falls_back_to_config() {
+        assert_eq!(
+            resolve_max_request_body_bytes_value(1024 * 1024, Some("4096")),
+            4096
+        );
+        assert_eq!(
+            resolve_max_request_body_bytes_value(42, Some("not-a-number")),
+            42
+        );
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoomRouter",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "identifier": "dev.loomrouter.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-tauri/tests/e2e/responses_http.rs
+++ b/src-tauri/tests/e2e/responses_http.rs
@@ -181,6 +181,92 @@ async fn responses_accepts_compaction_payload_above_default_axum_limit() {
 }
 
 #[tokio::test]
+async fn responses_accepts_compaction_payload_above_16_mib() {
+    let upstream_app = Router::new()
+        .route(
+            "/v1/chat/completions",
+            post(|_body: axum::body::Bytes| async {
+                axum::Json(serde_json::json!({
+                    "id": "chatcmpl-large",
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+                }))
+            }),
+        )
+        .layer(axum::extract::DefaultBodyLimit::max(64 * 1024 * 1024));
+    let upstream_url = spawn(upstream_app).await;
+
+    let mut providers = BTreeMap::new();
+    providers.insert(
+        "test".to_string(),
+        provider(
+            "test",
+            "Test",
+            ProviderProtocol::OpenAI,
+            format!("{upstream_url}/v1"),
+            "sk-test",
+            "m",
+            None,
+        ),
+    );
+    let proxy_url = spawn_proxy(AppConfig {
+        port: 0,
+        providers,
+        ..AppConfig::default()
+    })
+    .await;
+
+    // 17 MiB is deliberately above the old fixed 16 MiB ceiling, and below
+    // the new generous default, so this proves the compaction regression is
+    // gone without making the e2e test allocate a full 128 MiB payload.
+    let large_input = "x".repeat(17 * 1024 * 1024);
+    let resp = reqwest::Client::new()
+        .post(format!("{proxy_url}/v1/responses"))
+        .header("x-loomrouter-token", proxy::local_token())
+        .json(&serde_json::json!({
+            "model": "test/m",
+            "input": large_input,
+            "stream": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert!(status.is_success(), "unexpected response: {status} {body}");
+}
+
+#[tokio::test]
+async fn responses_rejects_payload_above_configured_limit() {
+    let proxy_url = spawn_proxy(AppConfig {
+        port: 0,
+        max_request_body_bytes: 1024,
+        ..AppConfig::default()
+    })
+    .await;
+
+    // Keep the body small enough that the proxy can emit its 413 before the
+    // client closes the socket mid-write. A large oversized body reliably
+    // triggers a connection reset instead of a readable HTTP response.
+    let oversized_input = "x".repeat(2 * 1024);
+    let resp = reqwest::Client::new()
+        .post(format!("{proxy_url}/v1/responses"))
+        .header("x-loomrouter-token", proxy::local_token())
+        .json(&serde_json::json!({
+            "model": "unused/m",
+            "input": oversized_input,
+            "stream": false,
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let status = resp.status();
+    let body = resp.text().await.unwrap();
+    assert_eq!(status.as_u16(), 413, "unexpected response: {status} {body}");
+}
+
+#[tokio::test]
 async fn e2e_005_migrated_single_key_routes_through_principal() {
     let upstream_app = Router::new().route(
         "/v1/responses",


### PR DESCRIPTION
## What changed, and why

Large Codex chats could fail automatic compaction with HTTP 413 because LoomRouter applied one global 16 MiB Axum body limit. The limit was evaluated after request decompression, so a full transcript sent to `/v1/responses` could exceed it during `run_auto_compact` and fail with `Failed to buffer the request body: length limit exceeded`.

This PR:

- raises the default body limit for `/v1/responses` and `/v1/responses/compact` to 128 MiB;
- makes that limit configurable through `max_request_body_bytes` and the `LOOM_ROUTER_MAX_REQUEST_BODY_BYTES` environment override;
- clamps configured values to a 1 GiB technical ceiling to prevent accidental local memory exhaustion;
- keeps `/v1/chat/completions` at 16 MiB instead of widening unrelated routes;
- treats zero as the safe default and falls back to config when the environment override is invalid;
- bumps the application version from 0.2.8 to 0.2.9, including synchronized manifests and release notes.

The proxy remains bound to localhost and protected by its local token. The larger default favors long-context Codex sessions while the per-route scope and hard ceiling bound memory exposure.

## How it was verified

Regression coverage added:

- `responses_accepts_body_larger_than_16_mib`, which sends a payload above the old 16 MiB ceiling and now reaches the authenticated `/v1/responses` handler;
- `responses_rejects_body_above_configured_limit`, which verifies HTTP 413 at an explicitly configured lower limit;
- unit coverage for default selection, configured values, environment precedence, invalid override fallback and 1 GiB clamping.

Full local quality gate:

- `bun run lint`
- `bun run test`: 156 tests passed
- `bun run build`: passed, with the existing chunk-size warning
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml`: 401 tests passed

## Checklist

- [x] The full gate passes locally, not just the part I touched
- [x] Tests live beside the code and are named as the sentence they assert
- [x] No request or response body is logged
- [x] No provider field name is read outside `translate.rs`
- [x] No Tauri command backend state or browser mock contract changed
- [x] Version bump is synchronized across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml` and `CHANGELOG.md`
