### PR TITLE
feat(agents): enable every routed model for subagents

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -314,6 +314,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,8 +764,18 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
 ]
 
 [[package]]
@@ -776,14 +792,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2261,7 +2301,9 @@ dependencies = [
  "http-body-util",
  "json5",
  "reqwest 0.12.28",
+ "rmcp",
  "rusqlite",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
  "sha2",
@@ -2772,6 +2814,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -3353,6 +3401,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
+dependencies = [
+ "base64 0.23.1",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
+dependencies = [
+ "darling 0.24.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3506,7 +3590,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -3531,8 +3615,10 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.2",
  "serde",
  "serde_json",
 ]
@@ -3545,8 +3631,20 @@ checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
- "serde_derive_internals",
+ "serde_derive_internals 0.29.1",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals 0.30.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3661,6 +3759,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3751,7 +3860,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4574,6 +4683,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,8 @@ tower-http = { version = "0.6", features = ["decompression-full"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 base64 = "0.22"
 sha2 = "0.10"
+rmcp = { version = "3.1.2", features = ["client", "transport-io"] }
+schemars = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/codex.rs
+++ b/src-tauri/src/codex.rs
@@ -49,10 +49,13 @@ use std::path::{Path, PathBuf};
 
 #[path = "codex/config_patch.rs"]
 mod config_patch;
+#[path = "codex/subagents.rs"]
+mod subagents;
 pub use config_patch::{
     active_slug, apply, current_root_model, multi_agent_enabled, owns_slug, published_slug, remove,
     set_multi_agent, BEGIN_MARK, END_MARK,
 };
+pub use subagents::serve_subagent_mcp;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct CodexStatus {

--- a/src-tauri/src/codex/agents/orchestrator.rs
+++ b/src-tauri/src/codex/agents/orchestrator.rs
@@ -63,7 +63,7 @@ pub(super) fn sync_orchestrator_skill_in(codex_home: &std::path::Path) -> anyhow
          \n\
          The `model:` values above are LoomRouter slugs. Use them as the exact model for spawned agents. Do not replace them with Claude Code's built-in models or Codex native models. If an agent has `inherits the current LoomRouter model`, keep the current session's LoomRouter-routed model; do not switch to another model.\n\
          \n\
-         A user-requested model is not limited to the saved roster. If the spawn tool accepts a free-form model, pass the requested LoomRouter slug exactly. If its schema exposes a closed model list, first use a saved agent whose configured model matches the request. If neither route can represent that model, report that the host tool rejected the model; never claim that LoomRouter itself lacks the model merely because it is absent from the roster.\n\
+         A user-requested model is not limited to the saved roster. If the native spawn tool accepts the requested LoomRouter slug, pass it exactly. If its schema exposes a closed model list or rejects the slug, call `loom_spawn_agents`, which accepts every currently enabled LoomRouter model. Only report a host limitation when neither tool is available; never claim that LoomRouter itself lacks the model merely because it is absent from the saved-agent roster.\n\
          \n\
          ## Operating rules (single injection)\n\
          \n\
@@ -77,9 +77,9 @@ pub(super) fn sync_orchestrator_skill_in(codex_home: &std::path::Path) -> anyhow
          \n\
          Spawning is a tool call, never a shell command. Do NOT look for a CLI, script, or executable named after an agent tool — none exists, and running one only wastes a turn.\n\
          \n\
-         The tool is normally `spawn_agent`. Depending on which multi-agent surface the session negotiated it can instead appear namespaced, such as `collaboration.spawn_agent`; use whichever one is actually in your tool list.\n\
+         The native tool is normally `spawn_agent`. Depending on which multi-agent surface the session negotiated it can instead appear namespaced, such as `collaboration.spawn_agent`. The LoomRouter fallback is `loom_spawn_agents`, sometimes exposed under an MCP namespace. Use the native tool for models it represents and the LoomRouter fallback for any enabled slug rejected by the native enum.\n\
          \n\
-         If neither is there, stop and say so, and point the user at `[features] multi_agent_v2 = true` in `~/.codex/config.toml`. Do not substitute thread tools such as `create_thread`, and do not quietly do the whole task yourself — the user asked for delegation, so a single-agent answer that does not mention the tool was missing is a wrong answer.\n\
+         If neither native spawn nor `loom_spawn_agents` exists, stop and say so, and point the user at `[features] multi_agent_v2 = true` plus re-applying the LoomRouter Codex integration. Do not substitute thread tools such as `create_thread`, and do not quietly do the whole task yourself — the user asked for delegation, so a single-agent answer that does not mention the missing tool is a wrong answer.\n\
          \n\
          1. Map each part of the user's request to the saved LoomRouter agent whose description matches it best. Saved agents have priority over ad hoc workers unless the user explicitly requests a different model or rules.\n\
          2. Treat omissions as delegation authority, not as blockers. When the request is subjective, broad or underspecified, infer the useful roles, task decomposition, worker count, models, fan-out and depth from the request, available roster, concurrency and token budget. Delegate immediately without asking the user to specify those parameters.\n\
@@ -90,7 +90,7 @@ pub(super) fn sync_orchestrator_skill_in(codex_home: &std::path::Path) -> anyhow
          7. Report completions in the chat as they arrive. For each finished subagent, emit a concise status containing the agent name, `completed` or `failed`, and a one-line result summary. Do not leave successful subagent work visible only in tool output.\n\
          8. Wait for all reachable workers, then explicitly state that the delegation tree is complete and consolidate their results into one answer. If some workers failed or were blocked, name them and preserve the successful results.\n\
          \n\
-         An absent roster match is not a reason to refuse delegation. Refuse only when the actual spawn tool cannot express the requested model or when its concurrency/depth policy blocks another child, and name that concrete constraint.\n"
+         An absent roster match is not a reason to refuse delegation. Refuse only when neither native spawn nor `loom_spawn_agents` is available, the model is disabled in LoomRouter, or the concurrency/depth policy blocks another child; name that concrete constraint.\n"
     );
 
     std::fs::create_dir_all(&dir)?;

--- a/src-tauri/src/codex/agents/store.rs
+++ b/src-tauri/src/codex/agents/store.rs
@@ -1,6 +1,7 @@
 use super::orchestrator::sync_orchestrator_skill_in;
 use crate::codex::codex_home;
 use crate::codex::config_patch::write_config_atomic;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 /// One custom Codex agent as managed by the LoomRouter UI.
@@ -22,7 +23,7 @@ pub struct AgentInfo {
     /// System instructions of the agent (`developer_instructions`).
     pub instructions: String,
     /// Free-form labels shown as colored tags in the UI and used to filter
-    /// the roster. Stored as `tags` in the agent TOML.
+    /// the roster. Stored outside agent TOMLs because Codex rejects unknown fields.
     #[serde(default)]
     pub tags: Vec<String>,
 }
@@ -52,6 +53,44 @@ fn agent_file(dir: &std::path::Path, name: &str) -> PathBuf {
     dir.join(format!("{name}.toml"))
 }
 
+fn tags_file(dir: &std::path::Path) -> PathBuf {
+    dir.parent()
+        .unwrap_or(dir)
+        .join("loom-router")
+        .join("agent-tags.json")
+}
+
+fn load_tags(dir: &std::path::Path) -> BTreeMap<String, Vec<String>> {
+    std::fs::read_to_string(tags_file(dir))
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+fn save_tags(dir: &std::path::Path, tags: &BTreeMap<String, Vec<String>>) -> anyhow::Result<()> {
+    let path = tags_file(dir);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    crate::secure_fs::write_private(&path, serde_json::to_vec_pretty(tags)?.as_slice())?;
+    Ok(())
+}
+
+fn normalized_tags(raw_tags: &[String]) -> Vec<String> {
+    let mut tags = Vec::new();
+    for raw in raw_tags {
+        let tag = raw.trim().to_string();
+        if !tag.is_empty()
+            && !tags
+                .iter()
+                .any(|known: &String| known.eq_ignore_ascii_case(&tag))
+        {
+            tags.push(tag);
+        }
+    }
+    tags
+}
+
 /// Codex requires a `description`. When the user (or this UI) never wrote
 /// one, derive a stable fallback from the first instruction line.
 fn derived_description(instructions: &str) -> String {
@@ -63,12 +102,16 @@ fn derived_description(instructions: &str) -> String {
     first.chars().take(120).collect()
 }
 
-fn agent_from_table(table: &toml::map::Map<String, toml::Value>, fallback_name: &str) -> AgentInfo {
+fn agent_from_table(
+    table: &toml::map::Map<String, toml::Value>,
+    fallback_name: &str,
+    metadata_tags: Option<&Vec<String>>,
+) -> AgentInfo {
     let get_str = |key: &str| table.get(key).and_then(toml::Value::as_str);
     let instructions = get_str("developer_instructions")
         .unwrap_or_default()
         .to_string();
-    let tags = table
+    let legacy_tags = table
         .get("tags")
         .and_then(toml::Value::as_array)
         .map(|values| {
@@ -87,7 +130,7 @@ fn agent_from_table(table: &toml::map::Map<String, toml::Value>, fallback_name: 
         effort: get_str("model_reasoning_effort").map(str::to_string),
         sandbox_mode: get_str("sandbox_mode").map(str::to_string),
         instructions,
-        tags,
+        tags: metadata_tags.cloned().unwrap_or(legacy_tags),
     }
 }
 
@@ -98,6 +141,7 @@ pub(super) fn agents_list_in(dir: &std::path::Path) -> anyhow::Result<Vec<AgentI
     if !dir.is_dir() {
         return Ok(out);
     }
+    let mut tags = load_tags(dir);
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
@@ -113,7 +157,27 @@ pub(super) fn agents_list_in(dir: &std::path::Path) -> anyhow::Result<Vec<AgentI
             .ok()
             .and_then(|raw| toml::from_str::<toml::Value>(&raw).ok());
         match parsed.and_then(|v| v.as_table().cloned()) {
-            Some(table) => out.push(agent_from_table(&table, &fallback)),
+            Some(mut table) => {
+                if let Some(legacy) = table.remove("tags") {
+                    let migrated = legacy
+                        .as_array()
+                        .map(|values| {
+                            values
+                                .iter()
+                                .filter_map(|value| value.as_str().map(str::to_string))
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default();
+                    tags.entry(fallback.clone())
+                        .or_insert_with(|| normalized_tags(&migrated));
+                    // Persist the only copy of UI metadata before removing
+                    // the unsupported field from the Codex-owned TOML.
+                    save_tags(dir, &tags)?;
+                    let rendered = toml::to_string_pretty(&toml::Value::Table(table.clone()))?;
+                    write_config_atomic(&path, &rendered)?;
+                }
+                out.push(agent_from_table(&table, &fallback, tags.get(&fallback)));
+            }
             // Unreadable/invalid files are skipped, never fatal for the list.
             None => tracing::warn!("skipping invalid agent file {}", path.display()),
         }
@@ -195,20 +259,11 @@ pub(super) fn agents_upsert_in(dir: &std::path::Path, agent: &AgentInfo) -> anyh
             table.remove("sandbox_mode");
         }
     }
-    // Tags are a LoomRouter UI concept, so they are written as a plain
-    // `tags` array that Codex ignores safely. Normalize duplicate labels so
-    // roster filtering remains stable across edits.
-    let mut tags = Vec::new();
-    let mut seen = Vec::<String>::new();
-    for raw in &agent.tags {
-        let tag = raw.trim().to_string();
-        if tag.is_empty() || seen.iter().any(|known| known.eq_ignore_ascii_case(&tag)) {
-            continue;
-        }
-        seen.push(tag.clone());
-        tags.push(toml::Value::String(tag));
-    }
-    table.insert("tags".into(), toml::Value::Array(tags));
+    // Codex parses agent TOMLs strictly and rejects UI-only keys.
+    table.remove("tags");
+    let mut tags = load_tags(dir);
+    tags.insert(agent.name.clone(), normalized_tags(&agent.tags));
+    save_tags(dir, &tags)?;
     let rendered = toml::to_string_pretty(&toml::Value::Table(table))?;
     // Same atomicity discipline as the config.toml writer (tmp + rename).
     write_config_atomic(&path, &rendered)?;
@@ -235,6 +290,10 @@ pub(super) fn agents_delete_in(dir: &std::path::Path, name: &str) -> anyhow::Res
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => return Err(e.into()),
+    }
+    let mut tags = load_tags(dir);
+    if tags.remove(name).is_some() {
+        save_tags(dir, &tags)?;
     }
     // The orchestrator skill embeds the agent roster; keep it in sync
     // (home derived from the agents dir, so tests stay in temp dirs).

--- a/src-tauri/src/codex/agents/tests/orchestrator.rs
+++ b/src-tauri/src/codex/agents/tests/orchestrator.rs
@@ -137,9 +137,10 @@ fn orchestrator_skill_distinguishes_host_model_limits_from_roster_membership() {
     let raw =
         std::fs::read_to_string(dir.path().join("skills/loom-orchestrator/SKILL.md")).unwrap();
 
-    assert!(raw.contains("If the spawn tool accepts a free-form model"));
-    assert!(raw.contains("If its schema exposes a closed model list"));
-    assert!(raw.contains("host tool rejected the model"));
+    assert!(raw.contains("If the native spawn tool accepts the requested LoomRouter slug"));
+    assert!(raw.contains("If its schema exposes a closed model list or rejects the slug"));
+    assert!(raw.contains("call `loom_spawn_agents`"));
+    assert!(raw.contains("every currently enabled LoomRouter model"));
     assert!(raw.contains("never claim that LoomRouter itself lacks the model"));
 }
 

--- a/src-tauri/src/codex/agents/tests/store.rs
+++ b/src-tauri/src/codex/agents/tests/store.rs
@@ -49,12 +49,14 @@ fn agents_round_trip_list_upsert_delete() {
     assert_eq!(parsed["model"].as_str(), Some("kimi-coding/k3"));
     assert_eq!(parsed["model_reasoning_effort"].as_str(), Some("high"));
     assert_eq!(parsed["sandbox_mode"].as_str(), Some("read-only"));
+    assert!(parsed.get("tags").is_none(), "Codex rejects unknown fields");
+    let metadata: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.path().join("loom-router/agent-tags.json")).unwrap(),
+    )
+    .unwrap();
     assert_eq!(
-        parsed["tags"].as_array().map(|tags| tags
-            .iter()
-            .filter_map(toml::Value::as_str)
-            .collect::<Vec<_>>()),
-        Some(vec!["review", "security"])
+        metadata["reviewer"],
+        serde_json::json!(["review", "security"])
     );
 
     // Update: dropping model/effort/sandbox removes the keys; an empty
@@ -169,6 +171,35 @@ fn agents_preserve_unknown_fields_on_round_trip() {
     assert_eq!(
         parsed["developer_instructions"].as_str(),
         Some("Use the docs MCP server. Cite versions.")
+    );
+}
+
+#[test]
+fn listing_migrates_legacy_tags_out_of_codex_agent_toml() {
+    let dir = tempfile::tempdir().unwrap();
+    let agents = dir.path().join("agents");
+    std::fs::create_dir_all(&agents).unwrap();
+    std::fs::write(
+        agents.join("reviewer.toml"),
+        "name = \"reviewer\"\n\
+         description = \"Review code\"\n\
+         developer_instructions = \"Review\"\n\
+         tags = [\"review\", \"security\"]\n",
+    )
+    .unwrap();
+
+    let listed = agents_list_in(&agents).unwrap();
+
+    assert_eq!(listed[0].tags, ["review", "security"]);
+    let raw = std::fs::read_to_string(agents.join("reviewer.toml")).unwrap();
+    assert!(!raw.contains("tags ="));
+    let metadata: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(dir.path().join("loom-router/agent-tags.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        metadata["reviewer"],
+        serde_json::json!(["review", "security"])
     );
 }
 

--- a/src-tauri/src/codex/config_patch.rs
+++ b/src-tauri/src/codex/config_patch.rs
@@ -289,6 +289,11 @@ fn managed_block(port: u16, catalog_path: &str, native_slug_mode: bool) -> Strin
     let token = crate::proxy::local_token()
         .replace('\\', "\\\\")
         .replace('"', "\\\"");
+    let executable = std::env::current_exe()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "loom-router".to_string())
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
     format!(
         "{BEGIN_MARK}\n\
          model_provider = \"loomrouter\"\n\
@@ -302,6 +307,13 @@ fn managed_block(port: u16, catalog_path: &str, native_slug_mode: bool) -> Strin
          requires_openai_auth = {requires_openai_auth}\n\
          supports_websockets = true\n\
          http_headers = {{ \"x-loomrouter-token\" = \"{token}\", \"Authorization\" = \"Bearer {token}\" }}\n\
+         \n\
+         [mcp_servers.loomrouter_subagents]\n\
+         command = \"{executable}\"\n\
+         args = [\"subagent-mcp\"]\n\
+         tool_timeout_sec = 600\n\
+         default_tools_approval_mode = \"approve\"\n\
+         supports_parallel_tool_calls = true\n\
          {END_MARK}",
         requires_openai_auth = !native_slug_mode,
     )
@@ -541,11 +553,14 @@ fn is_loomrouter_table(line: &str) -> bool {
         return false;
     };
     let inner = inner.trim();
-    inner == "model_providers.loomrouter" || inner.starts_with("model_providers.loomrouter.")
+    inner == "model_providers.loomrouter"
+        || inner.starts_with("model_providers.loomrouter.")
+        || inner == "mcp_servers.loomrouter_subagents"
+        || inner.starts_with("mcp_servers.loomrouter_subagents.")
 }
 
 /// Whether a `config.toml` carries content LoomRouter demonstrably owns: a
-/// `loomrouter` provider table, or a root `model_provider` pointing at it.
+/// `loomrouter` provider/subagent table, or a root `model_provider` pointing at it.
 fn has_loomrouter_content(raw: &str) -> bool {
     raw.lines().any(|l| {
         is_loomrouter_table(l)

--- a/src-tauri/src/codex/config_patch/tests.rs
+++ b/src-tauri/src/codex/config_patch/tests.rs
@@ -91,6 +91,30 @@ fn orphan_begin_is_recovered_by_ownership() {
 }
 
 #[test]
+fn orphan_recovery_removes_only_loomrouter_subagent_mcp() {
+    let raw = "# BEGIN loom-router-managed\n\
+model_provider = \"loomrouter\"\n\
+openai_base_url = \"x\"\n\
+model_catalog_json = \"y\"\n\
+\n\
+[model_providers.loomrouter]\n\
+wire_api = \"responses\"\n\
+\n\
+[mcp_servers.loomrouter_subagents]\n\
+command = \"/Applications/LoomRouter\"\n\
+args = [\"subagent-mcp\"]\n\
+\n\
+[mcp_servers.user_owned]\n\
+command = \"user-server\"\n";
+
+    let out = strip_managed_block(raw).unwrap();
+
+    assert!(!out.contains("loomrouter_subagents"));
+    assert!(out.contains("[mcp_servers.user_owned]"));
+    assert!(out.contains("command = \"user-server\""));
+}
+
+#[test]
 fn orphan_recovery_preserves_model_key_restore_path() {
     // The orphaned region may also swallow root `model`/effort keys the
     // desktop app re-emitted; `remove()` reconciles the root `model`
@@ -362,6 +386,21 @@ fn managed_block_is_valid_toml_with_websockets_on() {
         .as_str()
         .unwrap()
         .starts_with("Bearer "));
+    let subagents = &parsed["mcp_servers"]["loomrouter_subagents"];
+    assert!(subagents["command"].as_str().is_some_and(|v| !v.is_empty()));
+    assert_eq!(
+        subagents["args"].as_array().unwrap(),
+        &[toml::Value::String("subagent-mcp".into())]
+    );
+    assert_eq!(subagents["tool_timeout_sec"].as_integer(), Some(600));
+    assert_eq!(
+        subagents["default_tools_approval_mode"].as_str(),
+        Some("approve")
+    );
+    assert_eq!(
+        subagents["supports_parallel_tool_calls"].as_bool(),
+        Some(true)
+    );
     // User tables survive intact after the managed provider table.
     assert_eq!(parsed["plugins"]["a"]["enabled"].as_bool(), Some(true));
     // Stripping removes the whole block, including the provider table.

--- a/src-tauri/src/codex/subagents.rs
+++ b/src-tauri/src/codex/subagents.rs
@@ -1,0 +1,384 @@
+use crate::config::AppConfig;
+use futures::{stream, StreamExt};
+use rmcp::{
+    handler::server::{tool::ToolRouter, wrapper::Parameters},
+    model::{CallToolResult, ContentBlock, ServerCapabilities, ServerInfo},
+    schemars, tool, tool_handler, tool_router, ServerHandler, ServiceExt,
+};
+use serde::{Deserialize, Serialize};
+use std::{path::PathBuf, process::Stdio};
+
+const MAX_TASKS: usize = 8;
+const MAX_CONCURRENCY: usize = 4;
+const MAX_DEPTH: u8 = 3;
+const DEPTH_ENV: &str = "LOOM_ROUTER_SUBAGENT_DEPTH";
+
+fn model_is_enabled(config: &AppConfig, slug: &str) -> bool {
+    config.providers.iter().any(|(provider_id, provider)| {
+        provider.enabled
+            && provider.models.iter().any(|model| {
+                model.enabled
+                    && super::published_slug(provider_id, &model.id, config.native_slug_mode)
+                        == slug
+            })
+    })
+}
+
+fn enabled_model_slugs(config: &AppConfig) -> Vec<String> {
+    config
+        .providers
+        .iter()
+        .filter(|(_, provider)| provider.enabled)
+        .flat_map(|(provider_id, provider)| {
+            provider
+                .models
+                .iter()
+                .filter(|model| model.enabled)
+                .map(|model| super::published_slug(provider_id, &model.id, config.native_slug_mode))
+        })
+        .collect()
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SpawnTask {
+    /// Stable short name used to identify the result.
+    name: String,
+    /// Any enabled LoomRouter model slug, exactly as shown in the Codex picker.
+    model: String,
+    /// Complete, self-contained instructions for this worker.
+    prompt: String,
+    /// Codex sandbox mode. Defaults to workspace-write.
+    sandbox: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct SpawnRequest {
+    /// Independent tasks to execute in parallel, up to eight per call.
+    tasks: Vec<SpawnTask>,
+    /// Workspace root for every task. Defaults to the MCP process directory.
+    cwd: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SpawnResult {
+    name: String,
+    model: String,
+    status: &'static str,
+    output: String,
+}
+
+#[derive(Clone)]
+struct SubagentServer {
+    #[expect(dead_code, reason = "tool_handler macro accesses this router field")]
+    tool_router: ToolRouter<Self>,
+}
+
+#[tool_router]
+impl SubagentServer {
+    #[tool(
+        name = "loom_list_subagent_models",
+        description = "List every provider/model currently enabled in LoomRouter and accepted by loom_spawn_agents."
+    )]
+    async fn list_models(&self) -> Result<CallToolResult, rmcp::ErrorData> {
+        let text = serde_json::to_string_pretty(&enabled_model_slugs(&AppConfig::load())).map_err(
+            |error| {
+                rmcp::ErrorData::internal_error(
+                    format!("serializing enabled models failed: {error}"),
+                    None,
+                )
+            },
+        )?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
+    }
+
+    fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+    #[tool(
+        name = "loom_spawn_agents",
+        description = "Run independent Codex subagents with any provider/model currently enabled in LoomRouter. Use this when native spawn_agent rejects a model slug. Results include an explicit completed or failed status for every worker."
+    )]
+    async fn spawn_agents(
+        &self,
+        Parameters(request): Parameters<SpawnRequest>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        if request.tasks.is_empty() || request.tasks.len() > MAX_TASKS {
+            return Err(rmcp::ErrorData::invalid_params(
+                format!("tasks must contain between 1 and {MAX_TASKS} items"),
+                None,
+            ));
+        }
+        let depth = current_depth();
+        if depth >= MAX_DEPTH {
+            return Err(rmcp::ErrorData::invalid_params(
+                format!("subagent depth limit reached ({MAX_DEPTH})"),
+                None,
+            ));
+        }
+        let config = AppConfig::load();
+        for task in &request.tasks {
+            if !model_is_enabled(&config, &task.model) {
+                return Err(rmcp::ErrorData::invalid_params(
+                    format!("model '{}' is not enabled in LoomRouter", task.model),
+                    None,
+                ));
+            }
+            validate_sandbox(task.sandbox.as_deref())?;
+        }
+
+        let cwd = request
+            .cwd
+            .map(PathBuf::from)
+            .or_else(|| std::env::current_dir().ok())
+            .ok_or_else(|| rmcp::ErrorData::invalid_params("cwd is unavailable", None))?;
+        // Structured concurrency matters here: dropping a cancelled MCP call
+        // must drop the in-flight Command futures instead of detaching workers.
+        let results: Vec<SpawnResult> = stream::iter(request.tasks)
+            .map(|task| run_task(task, cwd.clone(), depth + 1))
+            .buffered(MAX_CONCURRENCY)
+            .collect()
+            .await;
+        let text = serde_json::to_string_pretty(&results).map_err(|error| {
+            rmcp::ErrorData::internal_error(format!("serializing results failed: {error}"), None)
+        })?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
+    }
+}
+
+#[tool_handler]
+impl ServerHandler for SubagentServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions("Use loom_spawn_agents for enabled LoomRouter models that the native spawn_agent model enum cannot represent. Report each returned worker status in the parent chat.")
+    }
+}
+
+fn current_depth() -> u8 {
+    std::env::var(DEPTH_ENV)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(0)
+}
+
+fn validate_sandbox(sandbox: Option<&str>) -> Result<(), rmcp::ErrorData> {
+    match sandbox.unwrap_or("workspace-write") {
+        "read-only" | "workspace-write" | "danger-full-access" => Ok(()),
+        value => Err(rmcp::ErrorData::invalid_params(
+            format!("unsupported sandbox '{value}'"),
+            None,
+        )),
+    }
+}
+
+async fn run_task(task: SpawnTask, cwd: PathBuf, depth: u8) -> SpawnResult {
+    let name = task.name;
+    let model = task.model;
+    let sandbox = task.sandbox.unwrap_or_else(|| "workspace-write".into());
+    let Some(binary) = super::codex_bin() else {
+        return SpawnResult {
+            name,
+            model,
+            status: "failed",
+            output: "Codex CLI not found".into(),
+        };
+    };
+    let mut command = tokio::process::Command::new(binary);
+    command.args(codex_task_args(&model, &sandbox, &cwd, &task.prompt));
+    command
+        .stdin(Stdio::null())
+        .kill_on_drop(true)
+        .env(DEPTH_ENV, depth.to_string());
+    crate::cli_locator::hide_console_window(command.as_std_mut());
+    let output = command.output().await;
+
+    match output {
+        Ok(output) => SpawnResult {
+            name,
+            model,
+            status: if output.status.success() {
+                "completed"
+            } else {
+                "failed"
+            },
+            output: extract_final_message(&output.stdout).unwrap_or_else(|| {
+                String::from_utf8_lossy(if output.stderr.is_empty() {
+                    &output.stdout
+                } else {
+                    &output.stderr
+                })
+                .trim()
+                .to_string()
+            }),
+        },
+        Err(error) => SpawnResult {
+            name,
+            model,
+            status: "failed",
+            output: error.to_string(),
+        },
+    }
+}
+
+fn codex_task_args(model: &str, sandbox: &str, cwd: &std::path::Path, prompt: &str) -> Vec<String> {
+    vec![
+        "--ask-for-approval".into(),
+        "never".into(),
+        "--sandbox".into(),
+        sandbox.into(),
+        "--model".into(),
+        model.into(),
+        "--cd".into(),
+        cwd.display().to_string(),
+        "exec".into(),
+        "--json".into(),
+        "--ephemeral".into(),
+        prompt.into(),
+    ]
+}
+
+fn extract_final_message(stdout: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(stdout)
+        .lines()
+        .rev()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .filter_map(|event| {
+            (event.get("type")?.as_str()? == "item.completed")
+                .then(|| event.get("item").cloned())
+                .flatten()
+        })
+        .filter(|item| item.get("type").and_then(|v| v.as_str()) == Some("agent_message"))
+        .filter_map(|item| {
+            item.get("text")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .next()
+}
+
+pub async fn serve_subagent_mcp() -> anyhow::Result<()> {
+    let service = SubagentServer::new()
+        .serve(rmcp::transport::stdio())
+        .await?;
+    service.waiting().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Provider, ProviderModel, ProviderProtocol};
+    use rmcp::ServiceExt;
+
+    fn config_with_models() -> AppConfig {
+        let mut config = AppConfig::default();
+        config.providers.insert(
+            "opencode-go".into(),
+            Provider {
+                id: "opencode-go".into(),
+                name: "OpenCode Go".into(),
+                protocol: ProviderProtocol::Responses,
+                base_url: "https://example.test/v1".into(),
+                api_key: None,
+                keys: Vec::new(),
+                rotation_enabled: false,
+                has_key: true,
+                context_window: None,
+                user_agent: None,
+                models: vec![
+                    ProviderModel {
+                        id: "deepseek-v4-flash".into(),
+                        label: None,
+                        context_window: Some(1_000_000),
+                        protocol: Some(ProviderProtocol::Responses),
+                        fast_mode: false,
+                        enabled: true,
+                        supports_vision: false,
+                    },
+                    ProviderModel {
+                        id: "disabled-model".into(),
+                        label: None,
+                        context_window: None,
+                        protocol: None,
+                        fast_mode: false,
+                        enabled: false,
+                        supports_vision: false,
+                    },
+                ],
+                enabled: true,
+            },
+        );
+        config
+    }
+
+    #[test]
+    fn only_enabled_provider_models_can_spawn() {
+        let config = config_with_models();
+        assert!(model_is_enabled(&config, "opencode-go/deepseek-v4-flash"));
+        assert!(!model_is_enabled(&config, "opencode-go/disabled-model"));
+        assert!(!model_is_enabled(&config, "missing/model"));
+    }
+
+    #[test]
+    fn enabled_model_list_tracks_provider_and_native_slug_mode() {
+        let mut config = config_with_models();
+        assert_eq!(
+            enabled_model_slugs(&config),
+            vec!["opencode-go/deepseek-v4-flash"]
+        );
+
+        config.native_slug_mode = true;
+        assert_eq!(enabled_model_slugs(&config), vec!["deepseek-v4-flash"]);
+
+        config.providers.get_mut("opencode-go").unwrap().enabled = false;
+        assert!(enabled_model_slugs(&config).is_empty());
+    }
+
+    #[test]
+    fn final_agent_message_is_extracted_from_codex_jsonl() {
+        let output = br#"{"type":"thread.started","thread_id":"x"}
+{"type":"item.completed","item":{"id":"1","type":"agent_message","text":"done"}}
+"#;
+        assert_eq!(extract_final_message(output).as_deref(), Some("done"));
+    }
+
+    #[test]
+    fn codex_global_options_precede_exec_subcommand() {
+        let args = codex_task_args(
+            "opencode-go/deepseek-v4-flash",
+            "read-only",
+            std::path::Path::new("/tmp/work"),
+            "Review",
+        );
+        let exec = args.iter().position(|arg| arg == "exec").unwrap();
+        let approval = args
+            .iter()
+            .position(|arg| arg == "--ask-for-approval")
+            .unwrap();
+        assert!(approval < exec);
+        assert_eq!(&args[exec..], ["exec", "--json", "--ephemeral", "Review"]);
+    }
+
+    #[tokio::test]
+    async fn mcp_handshake_advertises_model_list_and_spawn_tools() {
+        let (server_transport, client_transport) = tokio::io::duplex(16 * 1024);
+        let server = tokio::spawn(async move {
+            SubagentServer::new()
+                .serve(server_transport)
+                .await?
+                .waiting()
+                .await?;
+            anyhow::Ok(())
+        });
+        let client = ().serve(client_transport).await.unwrap();
+
+        let tools = client.list_tools(None).await.unwrap();
+        let names: Vec<&str> = tools.tools.iter().map(|tool| tool.name.as_ref()).collect();
+        assert!(names.contains(&"loom_list_subagent_models"));
+        assert!(names.contains(&"loom_spawn_agents"));
+
+        client.cancel().await.unwrap();
+        server.await.unwrap().unwrap();
+    }
+}

--- a/src-tauri/src/codex/subagents.rs
+++ b/src-tauri/src/codex/subagents.rs
@@ -104,29 +104,10 @@ impl SubagentServer {
         &self,
         Parameters(request): Parameters<SpawnRequest>,
     ) -> Result<CallToolResult, rmcp::ErrorData> {
-        if request.tasks.is_empty() || request.tasks.len() > MAX_TASKS {
-            return Err(rmcp::ErrorData::invalid_params(
-                format!("tasks must contain between 1 and {MAX_TASKS} items"),
-                None,
-            ));
-        }
         let depth = current_depth();
-        if depth >= MAX_DEPTH {
-            return Err(rmcp::ErrorData::invalid_params(
-                format!("subagent depth limit reached ({MAX_DEPTH})"),
-                None,
-            ));
-        }
         let config = AppConfig::load();
-        for task in &request.tasks {
-            if !model_is_enabled(&config, &task.model) {
-                return Err(rmcp::ErrorData::invalid_params(
-                    format!("model '{}' is not enabled in LoomRouter", task.model),
-                    None,
-                ));
-            }
-            validate_sandbox(task.sandbox.as_deref())?;
-        }
+        validate_spawn_request(&config, &request.tasks, depth)
+            .map_err(|message| rmcp::ErrorData::invalid_params(message, None))?;
 
         let cwd = request
             .cwd
@@ -162,13 +143,35 @@ fn current_depth() -> u8 {
         .unwrap_or(0)
 }
 
-fn validate_sandbox(sandbox: Option<&str>) -> Result<(), rmcp::ErrorData> {
+fn validate_spawn_request(
+    config: &AppConfig,
+    tasks: &[SpawnTask],
+    depth: u8,
+) -> Result<(), String> {
+    if tasks.is_empty() || tasks.len() > MAX_TASKS {
+        return Err(format!(
+            "tasks must contain between 1 and {MAX_TASKS} items"
+        ));
+    }
+    if depth >= MAX_DEPTH {
+        return Err(format!("subagent depth limit reached ({MAX_DEPTH})"));
+    }
+    for task in tasks {
+        if !model_is_enabled(config, &task.model) {
+            return Err(format!(
+                "model '{}' is not enabled in LoomRouter",
+                task.model
+            ));
+        }
+        validate_sandbox(task.sandbox.as_deref())?;
+    }
+    Ok(())
+}
+
+fn validate_sandbox(sandbox: Option<&str>) -> Result<(), String> {
     match sandbox.unwrap_or("workspace-write") {
         "read-only" | "workspace-write" | "danger-full-access" => Ok(()),
-        value => Err(rmcp::ErrorData::invalid_params(
-            format!("unsupported sandbox '{value}'"),
-            None,
-        )),
+        value => Err(format!("unsupported sandbox '{value}'")),
     }
 }
 
@@ -312,12 +315,104 @@ mod tests {
         config
     }
 
+    fn task(model: &str, sandbox: Option<&str>) -> SpawnTask {
+        SpawnTask {
+            name: "worker".into(),
+            model: model.into(),
+            prompt: "Review".into(),
+            sandbox: sandbox.map(str::to_string),
+        }
+    }
+
     #[test]
     fn only_enabled_provider_models_can_spawn() {
         let config = config_with_models();
         assert!(model_is_enabled(&config, "opencode-go/deepseek-v4-flash"));
         assert!(!model_is_enabled(&config, "opencode-go/disabled-model"));
         assert!(!model_is_enabled(&config, "missing/model"));
+    }
+
+    #[test]
+    fn spawn_request_accepts_every_supported_sandbox_and_task_boundary() {
+        let config = config_with_models();
+        for sandbox in [
+            None,
+            Some("read-only"),
+            Some("workspace-write"),
+            Some("danger-full-access"),
+        ] {
+            assert!(validate_spawn_request(
+                &config,
+                &[task("opencode-go/deepseek-v4-flash", sandbox)],
+                MAX_DEPTH - 1,
+            )
+            .is_ok());
+        }
+
+        let maximum = (0..MAX_TASKS)
+            .map(|_| task("opencode-go/deepseek-v4-flash", None))
+            .collect::<Vec<_>>();
+        assert!(validate_spawn_request(&config, &maximum, 0).is_ok());
+    }
+
+    #[test]
+    fn spawn_request_rejects_every_invalid_boundary() {
+        let config = config_with_models();
+        assert_eq!(
+            validate_spawn_request(&config, &[], 0).unwrap_err(),
+            "tasks must contain between 1 and 8 items"
+        );
+
+        let too_many = (0..=MAX_TASKS)
+            .map(|_| task("opencode-go/deepseek-v4-flash", None))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            validate_spawn_request(&config, &too_many, 0).unwrap_err(),
+            "tasks must contain between 1 and 8 items"
+        );
+        assert_eq!(
+            validate_spawn_request(
+                &config,
+                &[task("opencode-go/deepseek-v4-flash", None)],
+                MAX_DEPTH,
+            )
+            .unwrap_err(),
+            "subagent depth limit reached (3)"
+        );
+        assert_eq!(
+            validate_spawn_request(
+                &config,
+                &[task("opencode-go/deepseek-v4-flash", Some("invalid"))],
+                0,
+            )
+            .unwrap_err(),
+            "unsupported sandbox 'invalid'"
+        );
+        assert_eq!(
+            validate_spawn_request(&config, &[task("missing/model", None)], 0).unwrap_err(),
+            "model 'missing/model' is not enabled in LoomRouter"
+        );
+    }
+
+    #[test]
+    fn spawn_request_rejects_model_when_provider_becomes_disabled() {
+        let mut config = config_with_models();
+        config.providers.get_mut("opencode-go").unwrap().enabled = false;
+        assert!(
+            validate_spawn_request(&config, &[task("opencode-go/deepseek-v4-flash", None)], 0,)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn spawn_request_accepts_native_slug_mode() {
+        let mut config = config_with_models();
+        config.native_slug_mode = true;
+        assert!(validate_spawn_request(&config, &[task("deepseek-v4-flash", None)], 0,).is_ok());
+        assert!(
+            validate_spawn_request(&config, &[task("opencode-go/deepseek-v4-flash", None)], 0,)
+                .is_err()
+        );
     }
 
     #[test]
@@ -344,6 +439,23 @@ mod tests {
     }
 
     #[test]
+    fn final_agent_message_uses_latest_valid_agent_event() {
+        let output = br#"not-json
+{"type":"item.completed","item":{"type":"command_execution","text":"ignore"}}
+{"type":"item.completed","item":{"type":"agent_message","text":"first"}}
+{"type":"item.completed","item":{"type":"agent_message","text":"last"}}
+"#;
+        assert_eq!(extract_final_message(output).as_deref(), Some("last"));
+        assert_eq!(extract_final_message(b"not-json\n"), None);
+        assert_eq!(
+            extract_final_message(
+                br#"{"type":"item.completed","item":{"type":"command_execution"}}"#
+            ),
+            None
+        );
+    }
+
+    #[test]
     fn codex_global_options_precede_exec_subcommand() {
         let args = codex_task_args(
             "opencode-go/deepseek-v4-flash",
@@ -358,6 +470,9 @@ mod tests {
             .unwrap();
         assert!(approval < exec);
         assert_eq!(&args[exec..], ["exec", "--json", "--ephemeral", "Review"]);
+        assert_eq!(args[3], "read-only");
+        assert_eq!(args[5], "opencode-go/deepseek-v4-flash");
+        assert_eq!(args[7], "/tmp/work");
     }
 
     #[tokio::test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,5 +5,13 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    if std::env::args().nth(1).as_deref() == Some("subagent-mcp") {
+        let runtime = tokio::runtime::Runtime::new().expect("subagent MCP runtime");
+        if let Err(error) = runtime.block_on(loom_router_lib::codex::serve_subagent_mcp()) {
+            eprintln!("LoomRouter subagent MCP failed: {error}");
+            std::process::exit(1);
+        }
+        return;
+    }
     loom_router_lib::run()
 }


### PR DESCRIPTION
## Summary
- add a local MCP bridge that spawns Codex workers with any model currently enabled in LoomRouter
- register the bridge automatically in the managed Codex config, with bounded concurrency, recursion and explicit completion states
- migrate UI-only agent tags out of strict Codex agent TOMLs so saved specialists load correctly
- update the orchestrator skill to fall back automatically when native spawn_agent rejects a routed model

## Validation
- bun run lint
- bun run test (156 passed)
- bun run build
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path src-tauri/Cargo.toml (416 passed)
- MCP smoke: opencode-go/deepseek-v4-flash returned BRIDGE_OK
- MCP fan-out smoke: three concurrent DeepSeek Flash workers completed