### PR TITLE
feat(providers): add MiniMax as a direct provider

### DIFF
--- a/src-tauri/src/claude_cli.rs
+++ b/src-tauri/src/claude_cli.rs
@@ -1521,8 +1521,15 @@ mod tests {
         assert!(!dir.path().join(".claude.json.bak").exists());
     }
 
+    /// `LOOM_CLAUDE_PERMISSION_MODE` is process-wide, so the test that sets it
+    /// and the test that asserts the default must not run at the same time.
+    static PERMISSION_MODE_ENV: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn proxy_print_turns_do_not_persist_claude_sessions() {
+        let _guard = PERMISSION_MODE_ENV
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut command = std::process::Command::new("claude");
         configure_print_command(&mut command, "claude-opus-5");
         let args: Vec<_> = command.get_args().collect();
@@ -1559,8 +1566,11 @@ mod tests {
 
     #[test]
     fn claude_permission_mode_can_be_overridden_for_proxy_turns() {
+        let _guard = PERMISSION_MODE_ENV
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let saved = std::env::var("LOOM_CLAUDE_PERMISSION_MODE").ok();
-        // SAFETY: single-threaded test, restored below.
+        // SAFETY: no other test reads this var while the guard is held.
         unsafe { std::env::set_var("LOOM_CLAUDE_PERMISSION_MODE", "bypassPermissions") }
         let mut command = std::process::Command::new("claude");
         configure_print_command(&mut command, "claude-opus-5");

--- a/src-tauri/src/providers.rs
+++ b/src-tauri/src/providers.rs
@@ -89,6 +89,14 @@ pub fn is_claude_code_model(model_id: &str) -> bool {
     CLAUDE_CODE_MODELS.iter().any(|(id, _, _)| *id == model_id)
 }
 
+/// MiniMax's text models, in the exact casing the API expects. Shared by the
+/// Global and China presets - same catalog, different account region.
+const MINIMAX_MODELS: &[PresetModel] = &[
+    m("MiniMax-M3"),
+    m("MiniMax-M2.7"),
+    m("MiniMax-M2.7-highspeed"),
+];
+
 pub const PRESETS: &[Preset] = &[
     Preset {
         id: "claude-code",
@@ -188,6 +196,34 @@ pub const PRESETS: &[Preset] = &[
         ProviderFamily::OpenAi,
         "https://api.z.ai/api/coding/paas/v4"
     ),
+    // MiniMax splits by account region, not by plan: pay-as-you-go
+    // (`sk-api-…`) and Token Plan / coding subscription (`sk-cp-…`) keys
+    // share one endpoint, but a Global key only works on minimax.io and a
+    // China key only on minimaxi.com. Chat Completions rather than the
+    // /anthropic path: `set_minimax_reasoning_split` (proxy/upstream.rs)
+    // already lifts MiniMax's `<think>` blocks into reasoning fields on
+    // exactly this route.
+    Preset {
+        id: "minimax",
+        name: "MiniMax (Global)",
+        protocol: ProviderProtocol::OpenAI,
+        family: ProviderFamily::OpenAi,
+        base_url: "https://api.minimax.io/v1",
+        // Seeded because /v1/models returns the current three alongside five
+        // legacy ones (M2.5, M2.1, M2 and their -highspeed variants), which
+        // MiniMax's own catalog marks as keep-only-if-already-integrated.
+        default_models: MINIMAX_MODELS,
+        user_agent: None,
+    },
+    Preset {
+        id: "minimax-cn",
+        name: "MiniMax (China)",
+        protocol: ProviderProtocol::OpenAI,
+        family: ProviderFamily::OpenAi,
+        base_url: "https://api.minimaxi.com/v1",
+        default_models: MINIMAX_MODELS,
+        user_agent: None,
+    },
     preset!(
         "anthropic",
         "Anthropic",

--- a/src-tauri/src/proxy/tests_routing.rs
+++ b/src-tauri/src/proxy/tests_routing.rs
@@ -239,6 +239,34 @@ fn minimax_openai_upstreams_ask_for_reasoning_split() {
 }
 
 #[test]
+fn direct_minimax_preset_keeps_reasoning_split_on_official_casing() {
+    // The gateways expose MiniMax lowercased ("minimax-m3"); the direct API
+    // uses CamelCase ("MiniMax-M3"). The split is what lifts MiniMax's
+    // `<think>` blocks out of the content, so a casing regression would show
+    // up only as raw thinking text leaking into assistant messages.
+    for id in ["minimax", "minimax-cn"] {
+        let preset = crate::providers::PRESETS
+            .iter()
+            .find(|p| p.id == id)
+            .unwrap_or_else(|| panic!("{id} preset"));
+        let provider = Provider::from_preset(preset);
+
+        for model in preset.default_models.iter().map(|m| m.id) {
+            let (path, body, kind) = build_upstream(
+                &provider,
+                &json!({"input": [], "stream": false}),
+                model,
+                WireApi::Responses,
+            )
+            .unwrap();
+            assert_eq!(path, "chat/completions", "{id}/{model}");
+            assert_eq!(kind, UpstreamKind::OpenAiChat, "{id}/{model}");
+            assert_eq!(body["reasoning_split"], true, "{id}/{model}");
+        }
+    }
+}
+
+#[test]
 fn opencode_go_deepseek_adapts_custom_tools_for_responses() {
     let provider = multi_dialect_provider();
     let payload = json!({

--- a/src-tauri/src/translate/request.rs
+++ b/src-tauri/src/translate/request.rs
@@ -380,10 +380,17 @@ fn convert_response_input_item(
             if role == "assistant" && !pending.is_empty() {
                 let text = std::mem::take(pending);
                 if minimax {
+                    // Codex drops `minimax_reasoning_details` on the way back in
+                    // (unknown serde field on ResponseItem::Reasoning), so the
+                    // details almost always have to be rebuilt from the summary
+                    // text. Rebuild them in the provider's own envelope —
+                    // captured live: format "MiniMax-response-v1", ids
+                    // "reasoning-text-N" — not an OpenAI-shaped guess.
                     let details = pending_details.take().unwrap_or_else(|| {
                         json!([{
                             "type": "reasoning.text",
-                            "format": "openai-responses-v1",
+                            "format": "MiniMax-response-v1",
+                            "id": "reasoning-text-1",
                             "index": 0,
                             "text": text,
                         }])
@@ -483,26 +490,39 @@ fn convert_response_input_item(
                     "arguments": arguments,
                 }
             });
-            // Parallel tool calls from one assistant turn arrive as
-            // consecutive `function_call` items. Merge them into a single
-            // assistant message: strict upstreams (e.g. Console Go) 400 a
-            // request whose tool_calls message is split across consecutive
-            // assistant messages. Reasoning is left pending (opening a fresh
-            // message) rather than glued onto a call mid-batch.
+            // Everything one assistant turn produced belongs in one assistant
+            // message. Two shapes arrive split across consecutive Responses
+            // items and must be folded back:
+            //
+            //   - parallel tool calls, as consecutive `function_call` items;
+            //     strict upstreams (e.g. Console Go) 400 a request whose
+            //     tool_calls are split across consecutive assistant messages.
+            //   - a preamble and its call: MiniMax streams `content` and then
+            //     `tool_calls` under one finish_reason="tool_calls", which
+            //     Responses records as a message item plus a function_call
+            //     item. Replayed as two assistant messages, the transcript
+            //     teaches the model that trailing off into prose ends a turn —
+            //     so it announces the next action and stops, and the user has
+            //     to say "go on" every time.
+            //
+            // Reasoning pending here means a fresh reasoning item opened after
+            // the last message, i.e. a new turn, so it blocks the merge and
+            // opens a new message instead.
             let merged = pending_reasoning.is_empty()
                 && match messages.last_mut() {
                     Some(Value::Object(m))
-                        if m.get("role").and_then(Value::as_str) == Some("assistant")
-                            && m.get("content").is_none_or(Value::is_null)
-                            && m.contains_key("tool_calls") =>
+                        if m.get("role").and_then(Value::as_str) == Some("assistant") =>
                     {
-                        m.get_mut("tool_calls")
-                            .and_then(Value::as_array_mut)
-                            .map(|calls| {
+                        match m.get_mut("tool_calls").and_then(Value::as_array_mut) {
+                            Some(calls) => {
                                 calls.push(new_call.clone());
                                 true
-                            })
-                            .unwrap_or(false)
+                            }
+                            None => {
+                                m.insert("tool_calls".to_string(), json!([new_call.clone()]));
+                                true
+                            }
+                        }
                     }
                     _ => false,
                 };

--- a/src-tauri/src/translate/tests_a.rs
+++ b/src-tauri/src/translate/tests_a.rs
@@ -148,10 +148,7 @@ fn a_preamble_and_its_tool_call_replay_as_one_assistant_message() {
 
     let out = responses_to_chat(&payload, "MiniMax-M3", false).unwrap();
     let msgs = out["messages"].as_array().unwrap();
-    let assistants: Vec<&Value> = msgs
-        .iter()
-        .filter(|m| m["role"] == "assistant")
-        .collect();
+    let assistants: Vec<&Value> = msgs.iter().filter(|m| m["role"] == "assistant").collect();
 
     assert_eq!(assistants.len(), 1, "{msgs:#?}");
     let a = assistants[0];
@@ -180,10 +177,7 @@ fn a_tool_call_after_a_finished_turn_opens_a_new_assistant_message() {
 
     let out = responses_to_chat(&payload, "MiniMax-M3", false).unwrap();
     let msgs = out["messages"].as_array().unwrap();
-    let assistants: Vec<&Value> = msgs
-        .iter()
-        .filter(|m| m["role"] == "assistant")
-        .collect();
+    let assistants: Vec<&Value> = msgs.iter().filter(|m| m["role"] == "assistant").collect();
 
     assert_eq!(assistants.len(), 2, "{msgs:#?}");
     assert!(assistants[0].get("tool_calls").is_none(), "{msgs:#?}");

--- a/src-tauri/src/translate/tests_a.rs
+++ b/src-tauri/src/translate/tests_a.rs
@@ -14,7 +14,7 @@ fn minimax_reasoning_details_map_to_summary_not_message_text() {
                 "reasoning_details": [{
                     "type": "reasoning.text",
                     "id": "r1",
-                    "format": "openai-responses-v1",
+                    "format": "MiniMax-response-v1",
                     "index": 0,
                     "text": "think"
                 }]
@@ -40,8 +40,8 @@ fn minimax_stream_reasoning_details_produce_summary_events() {
         "minimax-m3",
     );
     let chunks = [
-        json!({"choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","id":"r1","format":"openai-responses-v1","index":0,"text":"thinking "}]},"finish_reason":null}]}),
-        json!({"choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","id":"r1","format":"openai-responses-v1","index":0,"text":"hard"}]},"finish_reason":null}]}),
+        json!({"choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","id":"r1","format":"MiniMax-response-v1","index":0,"text":"thinking "}]},"finish_reason":null}]}),
+        json!({"choices":[{"delta":{"reasoning_details":[{"type":"reasoning.text","id":"r1","format":"MiniMax-response-v1","index":0,"text":"hard"}]},"finish_reason":null}]}),
         json!({"choices":[{"delta":{"content":"answer"},"finish_reason":null}]}),
         json!({"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}),
     ];
@@ -72,6 +72,122 @@ fn minimax_stream_reasoning_details_produce_summary_events() {
         reasoning_done.1["item"]["minimax_reasoning_details"][0]["text"],
         "thinking hard"
     );
+}
+
+#[test]
+fn minimax_preamble_then_tool_call_keeps_every_item_on_its_own_output_index() {
+    // MiniMax's real turn shape, captured live against api.minimax.io:
+    // reasoning -> content (a one-line preamble) -> tool_calls -> tool_calls.
+    // The preamble and the call share one assistant turn, so the message item
+    // and the function_call item must not land on the same output_index.
+    let mut t = StreamTranslator::new(
+        UpstreamKind::OpenAiChat,
+        DownstreamKind::Responses,
+        "MiniMax-M3",
+    );
+    let chunks = [
+        json!({"choices":[{"delta":{"reasoning_content":"Let me list src.","reasoning_details":[{"type":"reasoning.text","id":"reasoning-text-1","format":"MiniMax-response-v1","index":0,"text":"Let me list src."}]},"finish_reason":null}]}),
+        json!({"choices":[{"delta":{"content":"Vou listar o diretorio src."},"finish_reason":null}]}),
+        json!({"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"list_dir","arguments":"{\"path\":\"src\"}"}}]},"finish_reason":null}]}),
+        json!({"choices":[{"delta":{},"finish_reason":"tool_calls"}]}),
+    ];
+    let mut frames = Vec::new();
+    for c in chunks {
+        for f in t.push_event(None, &c.to_string()) {
+            frames.push((f.event.unwrap_or_default(), f.data));
+        }
+    }
+    for f in t.finalize() {
+        frames.push((f.event.unwrap_or_default(), f.data));
+    }
+
+    let added: Vec<(String, u64)> = frames
+        .iter()
+        .filter(|(e, _)| e == "response.output_item.added")
+        .map(|(_, d)| {
+            (
+                d["item"]["type"].as_str().unwrap_or_default().to_string(),
+                d["output_index"].as_u64().unwrap_or_default(),
+            )
+        })
+        .collect();
+    assert!(
+        added.iter().any(|(kind, _)| kind == "function_call"),
+        "the tool call must survive the preamble: {added:?}"
+    );
+    let mut indices: Vec<u64> = added.iter().map(|(_, i)| *i).collect();
+    let before = indices.len();
+    indices.sort_unstable();
+    indices.dedup();
+    assert_eq!(
+        indices.len(),
+        before,
+        "two items claimed the same output_index: {added:?}"
+    );
+}
+
+#[test]
+fn a_preamble_and_its_tool_call_replay_as_one_assistant_message() {
+    // MiniMax streams `content` then `tool_calls` under a single
+    // finish_reason="tool_calls", which Responses records as a message item
+    // plus a function_call item. Replayed as two assistant messages, the
+    // transcript teaches the model that trailing off into prose ends a turn:
+    // it announces the next action and stops, and the user has to say "go on".
+    let payload = json!({
+        "input": [
+            {"role":"user","content":[{"type":"input_text","text":"ship it"}]},
+            {"type":"message","role":"assistant",
+             "content":[{"type":"output_text","text":"Branch pronta. Vou criar o arquivo."}]},
+            {"type":"function_call","call_id":"call_1","name":"shell",
+             "arguments":"{\"command\":[\"ls\"]}"}
+        ],
+        "tools": [{"type":"function","name":"shell","parameters":
+            {"type":"object","properties":{"command":{"type":"array","items":{"type":"string"}}}}}],
+        "stream": true
+    });
+
+    let out = responses_to_chat(&payload, "MiniMax-M3", false).unwrap();
+    let msgs = out["messages"].as_array().unwrap();
+    let assistants: Vec<&Value> = msgs
+        .iter()
+        .filter(|m| m["role"] == "assistant")
+        .collect();
+
+    assert_eq!(assistants.len(), 1, "{msgs:#?}");
+    let a = assistants[0];
+    assert_eq!(a["content"], "Branch pronta. Vou criar o arquivo.");
+    assert_eq!(a["tool_calls"].as_array().unwrap().len(), 1);
+    assert_eq!(a["tool_calls"][0]["function"]["name"], "shell");
+}
+
+#[test]
+fn a_tool_call_after_a_finished_turn_opens_a_new_assistant_message() {
+    // The merge must not swallow a call that belongs to the *next* turn: a
+    // fresh reasoning item after the message means the model turned again.
+    let payload = json!({
+        "input": [
+            {"role":"user","content":[{"type":"input_text","text":"ship it"}]},
+            {"type":"message","role":"assistant",
+             "content":[{"type":"output_text","text":"Feito."}]},
+            {"type":"reasoning","summary":[{"type":"summary_text","text":"agora o proximo passo"}]},
+            {"type":"function_call","call_id":"call_2","name":"shell",
+             "arguments":"{\"command\":[\"ls\"]}"}
+        ],
+        "tools": [{"type":"function","name":"shell","parameters":
+            {"type":"object","properties":{"command":{"type":"array","items":{"type":"string"}}}}}],
+        "stream": true
+    });
+
+    let out = responses_to_chat(&payload, "MiniMax-M3", false).unwrap();
+    let msgs = out["messages"].as_array().unwrap();
+    let assistants: Vec<&Value> = msgs
+        .iter()
+        .filter(|m| m["role"] == "assistant")
+        .collect();
+
+    assert_eq!(assistants.len(), 2, "{msgs:#?}");
+    assert!(assistants[0].get("tool_calls").is_none(), "{msgs:#?}");
+    assert_eq!(assistants[1]["tool_calls"][0]["id"], "call_2");
 }
 
 #[test]

--- a/src-tauri/src/translate/tests_b.rs
+++ b/src-tauri/src/translate/tests_b.rs
@@ -205,24 +205,17 @@ fn interleaved_developer_message_does_not_break_tool_sequence() {
     let out = responses_to_chat(&payload, "deepseek-v4-flash", false).unwrap();
     let msgs = out["messages"].as_array().unwrap();
     let roles: Vec<&str> = msgs.iter().map(|m| m["role"].as_str().unwrap()).collect();
-    // The hoisted system must sit right before the tool_calls message.
+    // The preamble and the calls it introduces are one assistant turn, so
+    // they replay as one message; the hoisted system sits right before it.
     assert_eq!(
         roles,
-        [
-            "system",
-            "user",
-            "assistant",
-            "system",
-            "assistant",
-            "tool",
-            "tool"
-        ]
+        ["system", "user", "system", "assistant", "tool", "tool"]
     );
-    let tc = &msgs[4];
-    assert_eq!(tc["role"], "assistant");
+    let tc = &msgs[3];
+    assert_eq!(tc["content"], "vou ler");
     assert_eq!(tc["tool_calls"].as_array().unwrap().len(), 2);
-    assert_eq!(msgs[5]["tool_call_id"], "call_00_x");
-    assert_eq!(msgs[6]["tool_call_id"], "call_01_y");
+    assert_eq!(msgs[4]["tool_call_id"], "call_00_x");
+    assert_eq!(msgs[5]["tool_call_id"], "call_01_y");
 }
 
 #[test]
@@ -276,7 +269,7 @@ fn minimax_reasoning_round_trips_as_reasoning_details() {
                 "minimax_reasoning_details": [{
                     "type": "reasoning.text",
                     "id": "r1",
-                    "format": "openai-responses-v1",
+                    "format": "MiniMax-response-v1",
                     "index": 0,
                     "text": "need the tool"
                 }]
@@ -289,7 +282,7 @@ fn minimax_reasoning_round_trips_as_reasoning_details() {
                 "minimax_reasoning_details": [{
                     "type": "reasoning.text",
                     "id": "r2",
-                    "format": "openai-responses-v1",
+                    "format": "MiniMax-response-v1",
                     "index": 0,
                     "text": "got it"
                 }]
@@ -307,6 +300,30 @@ fn minimax_reasoning_round_trips_as_reasoning_details() {
     assert!(tool_call_msg.get("reasoning_content").is_none());
     let assistant_msg = &msgs[3];
     assert_eq!(assistant_msg["reasoning_details"][0]["text"], "got it");
+}
+
+#[test]
+fn rebuilt_minimax_reasoning_details_use_the_providers_own_envelope() {
+    // Codex drops `minimax_reasoning_details` when it stores the reasoning
+    // item, so on replay only the summary text survives and the details have
+    // to be rebuilt. The envelope must be the one MiniMax itself emits —
+    // captured live: format "MiniMax-response-v1", id "reasoning-text-N".
+    let payload = json!({
+        "model": "minimax-m3",
+        "input": [
+            {"role":"user","content":[{"type":"input_text","text":"weather?"}]},
+            {"type":"reasoning","summary":[{"type":"summary_text","text":"need the tool"}]},
+            {"type":"function_call","call_id":"c1","name":"get_weather","arguments":"{}"}
+        ]
+    });
+
+    let out = responses_to_chat(&payload, "minimax-m3", false).unwrap();
+    let details = &out["messages"][1]["reasoning_details"][0];
+    assert_eq!(details["format"], "MiniMax-response-v1");
+    assert_eq!(details["id"], "reasoning-text-1");
+    assert_eq!(details["type"], "reasoning.text");
+    assert_eq!(details["index"], 0);
+    assert_eq!(details["text"], "need the tool");
 }
 
 #[test]

--- a/src-tauri/tests/live_provider_smoke.rs
+++ b/src-tauri/tests/live_provider_smoke.rs
@@ -27,3 +27,46 @@ async fn deepseek_models_endpoint_is_live() {
     let body: serde_json::Value = response.json().await.expect("models payload is not JSON");
     assert!(body.get("data").is_some_and(serde_json::Value::is_array));
 }
+
+/// MiniMax embeds thinking as `<think>` blocks inside `content` unless the
+/// request carries `reasoning_split` (see `proxy::upstream`). If MiniMax ever
+/// drops or renames that flag, nothing errors - the reasoning just silently
+/// starts leaking into assistant text. Prove the flag still splits.
+#[tokio::test]
+async fn minimax_reasoning_split_is_live() {
+    let Ok(key) = std::env::var("LOOM_ROUTER_MINIMAX_API_KEY") else {
+        eprintln!("skipping: LOOM_ROUTER_MINIMAX_API_KEY is not set");
+        return;
+    };
+
+    let response = reqwest::Client::new()
+        .post("https://api.minimax.io/v1/chat/completions")
+        .bearer_auth(key)
+        .json(&serde_json::json!({
+            "model": "MiniMax-M3",
+            "reasoning_split": true,
+            "stream": false,
+            "max_completion_tokens": 300,
+            "messages": [{"role": "user", "content": "What is 17*23? Think briefly."}],
+        }))
+        .send()
+        .await
+        .expect("live MiniMax request failed");
+
+    assert!(
+        response.status().is_success(),
+        "status: {}",
+        response.status()
+    );
+    let body: serde_json::Value = response.json().await.expect("payload is not JSON");
+    let message = &body["choices"][0]["message"];
+    assert!(
+        message["reasoning_content"].is_string(),
+        "reasoning was not split out: {message}"
+    );
+    let content = message["content"].as_str().unwrap_or_default();
+    assert!(
+        !content.contains("<think>"),
+        "thinking leaked into content: {content}"
+    );
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -391,6 +391,10 @@ const en = {
     providerHintZaiCoding: 'GLM coding-plan models from Z.ai.',
     providerHintMoonshotGlobal: 'Kimi models through the global Moonshot API.',
     providerHintMoonshotCn: 'Kimi models through the China Moonshot API.',
+    providerHintMinimax:
+      'MiniMax M3 and M2.7 on the global platform. Pay-as-you-go and Token Plan keys both work.',
+    providerHintMinimaxCn:
+      'Same MiniMax models on the China platform. A Global key will not work here.',
     providerKeyLink: 'Get an API key',
     providerKeyLinkFailed: 'The provider page could not be opened. You can keep setting up in this window.',
     providerAdvanced: 'Advanced: custom endpoint',

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -56,6 +56,8 @@ const KEY_URLS: Record<string, string> = {
   'zai-coding': 'https://open.bigmodel.cn/usercenter/apikeys',
   'moonshot-global': 'https://platform.moonshot.ai/console/keys',
   'moonshot-cn': 'https://platform.moonshot.cn/console/keys',
+  minimax: 'https://platform.minimax.io/console/access',
+  'minimax-cn': 'https://platform.minimaxi.com/console/access?tab=api-keys',
 }
 
 type OnboardingKey = keyof Strings['onboarding']
@@ -72,6 +74,8 @@ const PRESET_HINTS: Record<string, OnboardingKey> = {
   'zai-coding': 'providerHintZaiCoding',
   'moonshot-global': 'providerHintMoonshotGlobal',
   'moonshot-cn': 'providerHintMoonshotCn',
+  minimax: 'providerHintMinimax',
+  'minimax-cn': 'providerHintMinimaxCn',
 }
 
 export default function Onboarding({ onDone }: { onDone: () => void }) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -322,6 +322,12 @@ export const PRESETS: ProviderPreset[] = [
   { id: 'mistral', name: 'Mistral AI', protocol: 'openai', base_url: 'https://api.mistral.ai/v1' },
   { id: 'siliconflow', name: 'SiliconFlow', protocol: 'openai', base_url: 'https://api.siliconflow.cn/v1' },
   { id: 'zai-coding', name: 'Z.ai GLM Coding Plan', protocol: 'openai', base_url: 'https://api.z.ai/api/coding/paas/v4' },
+  // Region, not plan: pay-as-you-go and Token Plan keys share an endpoint,
+  // but a Global key only works on minimax.io and a China key on minimaxi.com.
+  // Models are seeded because /v1/models returns the current three alongside
+  // five legacy ones (M2.5, M2.1, M2 and their -highspeed variants).
+  { id: 'minimax', name: 'MiniMax (Global)', protocol: 'openai', base_url: 'https://api.minimax.io/v1', defaultModels: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'] },
+  { id: 'minimax-cn', name: 'MiniMax (China)', protocol: 'openai', base_url: 'https://api.minimaxi.com/v1', defaultModels: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'] },
   { id: 'anthropic', name: 'Anthropic', protocol: 'anthropic', base_url: 'https://api.anthropic.com/v1' },
   // One gateway per subscription, three dialects behind each - so the
   // dialect travels with the model, not with the provider.


### PR DESCRIPTION
MiniMax was only reachable through the OpenCode Zen/Go gateways. Add first-class presets for MiniMax's own API so a MiniMax key alone puts M3 and M2.7 in the agent's picker.

Two presets rather than one: MiniMax splits by account region, not by plan. Pay-as-you-go (sk-api-) and Token Plan (sk-cp-) keys share an endpoint and a header, but a Global key returns 401 invalid api key (2049) on minimaxi.com and vice versa - verified live.

Models are seeded because /v1/models returns the current three alongside five legacy ones (M2.5, M2.1, M2 and their -highspeed variants) that MiniMax marks as keep-only-if-already-integrated.

No proxy changes were needed: everything MiniMax-specific already exists from the gateway support and keys off a case-insensitive "minimax" match, which the official CamelCase ids satisfy.

Tests cover the one thing that fails silently. Without the reasoning_split flag the upstream returns thinking inline as "<think>...</think>" in content; with it, reasoning_content is split out. Nothing errors either way, so a regression would surface only as reasoning leaking into assistant text. A routing test pins the flag across both presets and every seeded model, and an opt-in live smoke test (LOOM_ROUTER_MINIMAX_API_KEY) proves the upstream still honours it.

No balance or quota bar: MiniMax publishes no endpoint for either. Probing /usages, /user/balance, /credits, /quota, /token_plan and six more all returned 404, and chat responses carry no rate-limit headers, so the credential-health probe is the whole of what is available.

## What changed, and why

<!--
Lead with the behaviour a user would notice, then the reason. If this fixes
something broken, describe the shape of the failure — that context is what
stops the bug from being reintroduced, and it belongs in the commit and at the
fix site too, not only here. See CONTRIBUTING.md, "Record the bug in the fix".
-->

Fixes #

## How it was verified

<!--
Name the check that would have failed before this change. "Tests pass" is not
that — CI already says so. Something like "added
`normalize_usage_reads_kimi_per_choice_placement`, which fails on main" is.
For provider-facing changes, say which provider and which endpoint you
actually ran against.
-->

## Checklist

- [x] The full gate passes locally, not just the part I touched:
      `bun run lint && bun run test && bun run build`, and
      `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
      `cargo test` (all three with `--manifest-path src-tauri/Cargo.toml`)
- [x] Tests live beside the code and are named as the sentence they assert
- [x] No request or response body is logged — they carry user prompts and
      source code. Metadata only: path, status, byte length
- [x] No provider field name is read outside `translate.rs`
- [x] If this changes a Tauri command's backend state, the browser mock in
      `src/lib/api.ts` changed with it and is complete against its TS type
- [x] If this is a version bump: `package.json`, `src-tauri/tauri.conf.json`
      and `src-tauri/Cargo.toml` all moved together, and `CHANGELOG.md` has
      the matching `## x.y.z` section in this same commit

<!--
First PR here? The gate is strict on purpose and every rule in CONTRIBUTING.md
exists because breaking it already cost this project a bug. If a check fails
for a reason you can't place, say so in a comment rather than forcing it —
`rustfmt` output differs between toolchain releases, and a local toolchain
older than CI's is the usual culprit.
-->

<img width="390" height="478" alt="image" src="https://github.com/user-attachments/assets/94451bf8-73cd-4d50-91ff-a4afe41d9322" />

