### PR TITLE
feat(ui): add a theme switcher with system, light and dark

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { NavLink, Outlet } from 'react-router'
 import { Bot, Boxes, LayoutDashboard, Minus, Plus, ScrollText, Server, Sparkles } from 'lucide-react'
 import { useStrings } from '@/i18n'
 import LanguageSwitcher from '@/components/LanguageSwitcher'
+import ThemeSwitcher from '@/components/ThemeSwitcher'
 import UpdateChecker from '@/components/UpdateChecker'
 import { isTauri } from '@/lib/api'
 import { Button } from '@/components/ui/button'
@@ -118,6 +119,7 @@ export default function Layout() {
           <div className="flex-1 min-w-0">
             <LanguageSwitcher />
           </div>
+          <ThemeSwitcher />
           <span className="shrink-0 text-xs text-muted-foreground">v{version}</span>
         </div>
       </aside>

--- a/src/components/ThemeSwitcher.test.tsx
+++ b/src/components/ThemeSwitcher.test.tsx
@@ -1,0 +1,29 @@
+// Guards the wiring the store test cannot see: the button cycles through all
+// three themes and each one has a translated label to announce.
+
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ThemeSwitcher from './ThemeSwitcher'
+import { setTheme } from '@/lib/theme'
+
+describe('ThemeSwitcher', () => {
+  it('cycles system -> light -> dark and back', async () => {
+    setTheme('system')
+    render(<ThemeSwitcher />)
+    const button = () => screen.getByRole('button')
+
+    expect(button()).toHaveAccessibleName('Theme: system')
+    await userEvent.click(button())
+    expect(button()).toHaveAccessibleName('Theme: light')
+    expect(document.documentElement).not.toHaveClass('dark')
+
+    await userEvent.click(button())
+    expect(button()).toHaveAccessibleName('Theme: dark')
+    expect(document.documentElement).toHaveClass('dark')
+
+    await userEvent.click(button())
+    expect(button()).toHaveAccessibleName('Theme: system')
+    expect(document.documentElement).not.toHaveClass('dark')
+  })
+})

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,37 @@
+// Compact theme toggle for the sidebar footer. Cycles system -> light ->
+// dark; the icon alone says which one is active, so it needs no label beside
+// it (the tooltip carries the translated name).
+
+import { Monitor, Moon, Sun } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { useStrings } from '@/i18n'
+import { setTheme, useTheme, type Theme } from '@/lib/theme'
+
+const ORDER: Theme[] = ['system', 'light', 'dark']
+
+const ICONS = { system: Monitor, light: Sun, dark: Moon } as const
+
+export default function ThemeSwitcher() {
+  const s = useStrings()
+  const theme = useTheme()
+  const Icon = ICONS[theme]
+  const labels: Record<Theme, string> = {
+    system: s.common.themeSystem,
+    light: s.common.themeLight,
+    dark: s.common.themeDark,
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-8 w-8 shrink-0"
+      title={labels[theme]}
+      aria-label={labels[theme]}
+      onClick={() => setTheme(ORDER[(ORDER.indexOf(theme) + 1) % ORDER.length])}
+    >
+      <Icon className="size-4" />
+    </Button>
+  )
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -300,6 +300,9 @@ const en = {
     zoomOut: 'Zoom out',
     zoomIn: 'Zoom in',
     zoomReset: 'Reset zoom to 100%',
+    themeSystem: 'Theme: system',
+    themeLight: 'Theme: light',
+    themeDark: 'Theme: dark',
   },
   updater: {
     checking: 'Checking for updates...',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -298,6 +298,9 @@ const es: DeepPartial<Strings> = {
     zoomOut: 'Reducir zoom',
     zoomIn: 'Aumentar zoom',
     zoomReset: 'Restablecer zoom al 100%',
+    themeSystem: 'Tema: sistema',
+    themeLight: 'Tema: claro',
+    themeDark: 'Tema: oscuro',
   },
   updater: {
     checking: 'Buscando actualizaciones...',

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -297,6 +297,9 @@ const pt: DeepPartial<Strings> = {
     zoomOut: 'Diminuir zoom',
     zoomIn: 'Aumentar zoom',
     zoomReset: 'Redefinir zoom para 100%',
+    themeSystem: 'Tema: sistema',
+    themeLight: 'Tema: claro',
+    themeDark: 'Tema: escuro',
   },
   updater: {
     checking: 'Verificando atualizações...',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -296,6 +296,9 @@ const zh: DeepPartial<Strings> = {
     zoomOut: '缩小',
     zoomIn: '放大',
     zoomReset: '重置缩放为 100%',
+    themeSystem: '主题：跟随系统',
+    themeLight: '主题：浅色',
+    themeDark: '主题：深色',
   },
   updater: {
     checking: '正在检查更新...',

--- a/src/lib/theme.test.ts
+++ b/src/lib/theme.test.ts
@@ -1,0 +1,28 @@
+// The store is a module singleton applied to <html>, so the risk is not the
+// cycle order but the two side effects: the class landing on the root element
+// and the choice surviving a reload.
+
+import { describe, expect, it } from 'vitest'
+import { getTheme, resolveTheme, setTheme } from './theme'
+
+describe('theme store', () => {
+  it('toggles the dark class on <html> and persists the choice', () => {
+    setTheme('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+    expect(localStorage.getItem('loomrouter.theme')).toBe('dark')
+
+    setTheme('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+    expect(localStorage.getItem('loomrouter.theme')).toBe('light')
+
+    expect(getTheme()).toBe('light')
+  })
+
+  it('resolves system against the OS preference, not the stored value', () => {
+    // jsdom reports no dark preference, so system must paint light even
+    // though the previous test left the store on an explicit theme.
+    setTheme('system')
+    expect(resolveTheme()).toBe('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+})

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,86 @@
+// Theme store. Mirrors the i18n module store (useSyncExternalStore, no
+// Provider in the tree) so the switcher re-renders without threading state
+// through Layout. Tailwind runs with darkMode: ["class"] and index.css
+// already ships the `.dark` variable block, so applying a theme is only a
+// matter of toggling `dark` on <html>.
+
+import { useSyncExternalStore } from 'react'
+
+export type Theme = 'system' | 'light' | 'dark'
+
+const STORAGE_KEY = 'loomrouter.theme'
+
+// jsdom (and restricted webviews) may not implement matchMedia.
+const media =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-color-scheme: dark)')
+    : null
+
+function loadTheme(): Theme {
+  try {
+    const saved = window.localStorage.getItem(STORAGE_KEY)
+    if (saved === 'system' || saved === 'light' || saved === 'dark') {
+      return saved
+    }
+  } catch {
+    // localStorage unavailable (e.g. restricted webview) - fall through.
+  }
+  return 'system'
+}
+
+let currentTheme: Theme = loadTheme()
+
+const listeners = new Set<() => void>()
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function emit(): void {
+  for (const listener of listeners) listener()
+}
+
+/// The theme actually painted: `system` resolves against the OS preference.
+export function resolveTheme(theme: Theme = currentTheme): 'light' | 'dark' {
+  if (theme !== 'system') return theme
+  return media?.matches ? 'dark' : 'light'
+}
+
+function apply(): void {
+  document.documentElement.classList.toggle('dark', resolveTheme() === 'dark')
+}
+
+export function getTheme(): Theme {
+  return currentTheme
+}
+
+export function setTheme(next: Theme): void {
+  if (next === currentTheme) return
+  currentTheme = next
+  apply()
+  try {
+    window.localStorage.setItem(STORAGE_KEY, next)
+  } catch {
+    // Persistence is best-effort; the in-memory switch still applies.
+  }
+  emit()
+}
+
+export function useTheme(): Theme {
+  return useSyncExternalStore(subscribe, getTheme)
+}
+
+// Run at import time: main.tsx pulls this in through Layout before the first
+// render, so the initial paint already carries the right class - no flash of
+// the light theme on startup.
+apply()
+
+// The OS can flip under us while `system` is selected.
+media?.addEventListener('change', () => {
+  if (currentTheme !== 'system') return
+  apply()
+  emit()
+})


### PR DESCRIPTION
## What changed, and why

The sidebar footer gains a theme control next to the language selector,
cycling **system → light → dark**. `system` is the default and follows
`prefers-color-scheme`; the choice persists in `localStorage` under
`loomrouter.theme`, alongside the existing `loomrouter.locale` and
`loomrouter.zoom`.

The dark theme itself was already in the tree and completely unreachable:
`darkMode: ["class"]` in `tailwind.config.js`, the full `.dark` variable
block in `src/index.css`, and `dark:` variants throughout `button.tsx`,
`badge.tsx`, `input.tsx`, `switch.tsx`, `tabs.tsx` and the page-level accent
colors. Nothing ever put the `dark` class on `<html>`, so none of it could
render. This PR adds only the missing control — no CSS variable and no
`dark:` variant changed.

Two details worth naming, both recorded at the fix site:

- **`theme.ts` applies at import time, not in an effect.** `main.tsx` pulls
  it in through `Layout` before the first render, so startup doesn't paint a
  light frame and then flip. An effect-based apply flashes.
- **`system` re-resolves on the OS preference changing.** LoomRouter sits in
  the tray for days rather than being reloaded, so a desktop that switches to
  dark at sunset would otherwise leave one bright window behind until a
  restart.

The store mirrors `i18n/index.ts` — a module-level `useSyncExternalStore`,
no Provider in the tree — since the switcher is a single leaf and threading
theme state through `Layout` would buy nothing.

`CHANGELOG.md` is untouched: it is written per release section, and this is
not a version bump.

Fixes #

## How it was verified

Two tests, both failing before this change because neither the store nor the
component existed:

- `src/lib/theme.test.ts` — `theme store` asserts the `dark` class actually
  lands on `document.documentElement` and that the choice reaches
  `localStorage`, then that `system` resolves against the OS preference
  rather than the last stored value. The store is a module singleton with two
  side effects outside React; those side effects are the whole risk.
- `src/components/ThemeSwitcher.test.tsx` — `cycles system -> light -> dark
  and back` covers the wiring the store test cannot see: that each step has a
  translated accessible name (a missing `s.common.theme*` key would surface
  here) and that the class on `<html>` tracks the button.

Beyond the suite, the built frontend was driven in a real browser against
`bun run dev`: the cycle reports `system → light → dark` with
`documentElement.classList.contains('dark')` following it, and `dark`
survives a reload. All six routes plus the Analytics tab were rendered in
dark and read correctly — including `AnalyticsChart`, whose axes and labels
use `currentColor` and so follow the theme with no change. No new console
errors.

Locale strings were added to all four locales rather than English alone,
since `src/i18n/i18n.test.ts` asserts partial parity against `en`.

## Checklist

- [x] The full gate passes locally, not just the part I touched:
      `bun run lint && bun run test && bun run build`, and
      `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
      `cargo test` (all three with `--manifest-path src-tauri/Cargo.toml`)
- [x] Tests live beside the code and are named as the sentence they assert
- [x] No request or response body is logged — they carry user prompts and
      source code. Metadata only: path, status, byte length
- [x] No provider field name is read outside `translate.rs`
- [x] If this changes a Tauri command's backend state, the browser mock in
      `src/lib/api.ts` changed with it and is complete against its TS type
      — n/a, this is frontend-only and touches no Tauri command
- [x] If this is a version bump: `package.json`, `src-tauri/tauri.conf.json`
      and `src-tauri/Cargo.toml` all moved together, and `CHANGELOG.md` has
      the matching `## x.y.z` section in this same commit — n/a, not a bump