### PR TITLE
feat(server): prevent sleep during model activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 Written for the person installing the build. Internal churn is left out.
 
+## 0.2.12
+
+### Added
+
+- **LoomRouter can keep the computer awake while a model is working.** A new
+  setting on the Server screen chooses when idle sleep is prevented: during
+  model activity, the whole time Loom is on, or never. Activity mode covers
+  in-flight requests, open realtime WebSocket sessions, and the 15 minutes
+  after the last one finishes. The display is never forced on in any mode.
+
+  **This is on by default, including on upgrade.** Existing installs pick up
+  "During model activity" because the setting is absent from their saved
+  configuration. Pick "Never" on the Server screen to restore the previous
+  behaviour, where a long routed turn could be cut short by the machine
+  going to sleep.
+
 ## 0.2.10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loom-router",
   "private": true,
-  "version": "0.2.11",
+  "version": "0.2.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2361,7 +2361,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loom-router"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -748,6 +748,16 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -764,6 +774,20 @@ checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core 0.24.0",
  "darling_macro 0.24.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -790,6 +814,17 @@ dependencies = [
  "quote",
  "strsim",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -848,6 +883,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.119",
 ]
 
@@ -2166,6 +2232,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keepawake"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d950f8c457c023d71a2b7fa0a3550e8eb5127811895b666086ff10304911d9a"
+dependencies = [
+ "cfg-if",
+ "derive_builder",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "thiserror 2.0.20",
+ "windows 0.62.2",
+ "zbus",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2372,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "json5",
+ "keepawake",
  "reqwest 0.12.28",
  "rmcp",
  "rusqlite",
@@ -2308,6 +2390,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "toml 0.8.2",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2542,7 +2625,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -2614,6 +2699,20 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.1",
  "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "dispatch2",
  "libc",
  "objc2",
  "objc2-core-foundation",
@@ -4166,7 +4265,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -4248,7 +4347,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4347,7 +4446,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.20",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -4416,7 +4515,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4441,7 +4540,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5364,7 +5463,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -5388,7 +5487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.20",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5444,11 +5543,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -5458,6 +5569,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5494,7 +5614,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5539,6 +5670,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5677,6 +5818,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5910,7 +6060,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -43,7 +43,9 @@ base64 = "0.23"
 sha2 = "0.10"
 rmcp = { version = "3.1.2", features = ["client", "transport-io"] }
 schemars = "1"
+keepawake = "0.6.1"
 
 [dev-dependencies]
 tempfile = "3"
 tokio-tungstenite = "0.29"
+tower = { version = "0.5", features = ["util"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -2,7 +2,7 @@
 name = "loom-router"
 # Kept in lockstep with package.json and tauri.conf.json; the release
 # workflow verifies all three against the tag.
-version = "0.2.11"
+version = "0.2.12"
 description = "Weave any model into your coding agent's picker."
 authors = ["LoomRouter contributors"]
 license = "MIT"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -28,6 +28,15 @@ pub const MAX_REQUEST_BODY_BYTES_HARD_LIMIT: usize = 1024 * 1024 * 1024;
 /// reinterpreting fields written by an older build.
 pub const CURRENT_SCHEMA_VERSION: u32 = 1;
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SleepPreventionMode {
+    Never,
+    #[default]
+    WhileActive,
+    Always,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 #[derive(Default)]
@@ -243,6 +252,10 @@ pub struct AppConfig {
     /// an OpenAI login (see codex.rs).
     #[serde(default)]
     pub native_slug_mode: bool,
+    /// When LoomRouter should prevent idle system sleep. Display sleep is
+    /// deliberately unaffected in every mode.
+    #[serde(default)]
+    pub sleep_prevention: SleepPreventionMode,
     /// Per-model context windows applied to native Codex catalog entries.
     /// The upstream catalog remains the default until the user explicitly
     /// overrides a slug, so LoomRouter never invents a larger limit silently.
@@ -312,6 +325,7 @@ impl Default for AppConfig {
             side_call_fallback: None,
             visual_assistance: VisualAssistanceConfig::default(),
             native_slug_mode: false,
+            sleep_prevention: SleepPreventionMode::default(),
             native_model_context_overrides: BTreeMap::new(),
             active_model: None,
             codex_model_backup: None,
@@ -664,6 +678,35 @@ impl AppConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn missing_sleep_prevention_config_defaults_to_activity() {
+        let config: AppConfig = serde_json::from_str("{}").unwrap();
+
+        assert_eq!(config.sleep_prevention, SleepPreventionMode::WhileActive);
+    }
+
+    #[test]
+    fn sleep_prevention_modes_round_trip_as_stable_config_values() {
+        for (mode, value) in [
+            (SleepPreventionMode::Never, "never"),
+            (SleepPreventionMode::WhileActive, "while_active"),
+            (SleepPreventionMode::Always, "always"),
+        ] {
+            let config = AppConfig {
+                sleep_prevention: mode,
+                ..AppConfig::default()
+            };
+            let json = serde_json::to_value(&config).unwrap();
+            assert_eq!(json["sleep_prevention"], value);
+            assert_eq!(
+                serde_json::from_value::<AppConfig>(json)
+                    .unwrap()
+                    .sleep_prevention,
+                mode
+            );
+        }
+    }
     use serde_json::json;
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub mod stats;
 pub mod tooling;
 pub mod translate;
 pub mod visual;
+mod wake_lock;
 
 mod tray;
 
@@ -119,6 +120,7 @@ pub fn run() {
             commands::set_multi_agent,
             commands::set_side_call_fallback,
             commands::set_native_slug_mode,
+            commands::set_sleep_prevention,
             commands::set_native_model_context_override,
             commands::clear_native_model_context_override,
             commands::set_onboarding_step,
@@ -137,7 +139,7 @@ pub fn run() {
 
 // Tauri commands live in lib.rs-adjacent module to keep the boundary thin.
 pub mod commands {
-    use crate::config::{AppConfig, Provider, VisualAssistanceConfig};
+    use crate::config::{AppConfig, Provider, SleepPreventionMode, VisualAssistanceConfig};
     use crate::state::{AppState, ServerStatus, SetupStatus};
     use tauri::State;
 
@@ -425,6 +427,17 @@ pub mod commands {
     ) -> Result<(), String> {
         state
             .set_native_slug_mode(enabled)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    #[tauri::command]
+    pub async fn set_sleep_prevention(
+        state: State<'_, AppState>,
+        mode: SleepPreventionMode,
+    ) -> Result<(), String> {
+        state
+            .set_sleep_prevention(mode)
             .await
             .map_err(|e| e.to_string())
     }

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -21,16 +21,17 @@ use axum::{
     body::Body,
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
-        DefaultBodyLimit, State as AxState,
+        DefaultBodyLimit, Request, State as AxState,
     },
     http::{HeaderMap, StatusCode},
-    middleware::{self},
+    middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
     Json, Router,
 };
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
+use http_body_util::BodyExt;
 use serde_json::{json, Value};
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::sync::{Arc, Mutex};
@@ -79,6 +80,37 @@ type EffectiveRoute = RoutePlan;
 /// users with an unusually large Codex transcript who do not want to edit
 /// `config.json` or wait for the next config-aware server start.
 const MAX_REQUEST_BODY_BYTES_ENV: &str = "LOOM_ROUTER_MAX_REQUEST_BODY_BYTES";
+
+fn is_model_activity_path(path: &str) -> bool {
+    matches!(
+        path,
+        "/v1/responses"
+            | "/v1/responses/compact"
+            | "/v1/chat/completions"
+            | "/images/generations"
+            | "/images/edits"
+            | "/v1/images/generations"
+            | "/v1/images/edits"
+    )
+}
+
+async fn track_model_activity(
+    AxState(wake): AxState<crate::wake_lock::WakeController>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if !is_model_activity_path(request.uri().path()) {
+        return next.run(request).await;
+    }
+    let lease = wake.begin_activity();
+    let response = next.run(request).await;
+    let (parts, body) = response.into_parts();
+    let guarded = body.map_frame(move |frame| {
+        let _ = &lease;
+        frame
+    });
+    Response::from_parts(parts, Body::new(guarded))
+}
 
 /// Body ceiling for OpenAI-compatible `/v1/chat/completions` requests.
 ///
@@ -132,6 +164,7 @@ struct ProxyCtx {
     /// the conversation's thread still alive — a per-session cache would
     /// lose everything on reconnect and reset the context window to zero.
     history: Arc<Mutex<WsHistory>>,
+    wake: crate::wake_lock::WakeController,
 }
 
 // ---------------------------------------------------------------------------
@@ -170,6 +203,20 @@ pub fn router(config: SharedConfig, stats: SharedStats) -> Router {
 }
 
 pub fn router_with_pools(config: SharedConfig, stats: SharedStats, key_pools: KeyPools) -> Router {
+    router_with_pools_and_wake(
+        config,
+        stats,
+        key_pools,
+        crate::wake_lock::WakeController::disabled(),
+    )
+}
+
+pub(crate) fn router_with_pools_and_wake(
+    config: SharedConfig,
+    stats: SharedStats,
+    key_pools: KeyPools,
+    wake: crate::wake_lock::WakeController,
+) -> Router {
     // Materialize the local token at startup so the first request never
     // pays (or races) initialization.
     let _ = local_token();
@@ -183,7 +230,9 @@ pub fn router_with_pools(config: SharedConfig, stats: SharedStats, key_pools: Ke
             .build()
             .expect("reqwest client"),
         history: Arc::new(Mutex::new(WsHistory::new())),
+        wake,
     };
+    let activity = ctx.wake.clone();
     Router::new()
         .route("/health", get(health))
         .route("/v1/models", get(handle_models))
@@ -228,6 +277,10 @@ pub fn router_with_pools(config: SharedConfig, stats: SharedStats, key_pools: Ke
         // The Codex App sends request bodies compressed (gzip/br/zstd).
         // Decompress transparently before handlers see the bytes.
         .layer(tower_http::decompression::RequestDecompressionLayer::new())
+        .layer(middleware::from_fn_with_state(
+            activity,
+            track_model_activity,
+        ))
         // Every route (including /health and the WS upgrade) requires the
         // local token; see `auth_gate`.
         .layer(middleware::from_fn(auth_gate))

--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -81,17 +81,11 @@ type EffectiveRoute = RoutePlan;
 /// `config.json` or wait for the next config-aware server start.
 const MAX_REQUEST_BODY_BYTES_ENV: &str = "LOOM_ROUTER_MAX_REQUEST_BODY_BYTES";
 
+/// Every route except the two cheap metadata ones counts as model activity.
+/// Stated as a denylist so a route added later is covered by construction —
+/// an allowlist would silently let a new endpoint idle-sleep mid-stream.
 fn is_model_activity_path(path: &str) -> bool {
-    matches!(
-        path,
-        "/v1/responses"
-            | "/v1/responses/compact"
-            | "/v1/chat/completions"
-            | "/images/generations"
-            | "/images/edits"
-            | "/v1/images/generations"
-            | "/v1/images/edits"
-    )
+    !matches!(path, "/health" | "/v1/models")
 }
 
 async fn track_model_activity(
@@ -104,6 +98,17 @@ async fn track_model_activity(
     }
     let lease = wake.begin_activity();
     let response = next.run(request).await;
+    // The denylist above cannot see the route table, so a path is only known to
+    // have missed it once the status comes back. Cancel rather than end the
+    // lease: a client polling an unknown endpoint must not renew the grace
+    // window on every miss.
+    if matches!(
+        response.status(),
+        StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+    ) {
+        lease.cancel();
+        return response;
+    }
     let (parts, body) = response.into_parts();
     let guarded = body.map_frame(move |frame| {
         let _ = &lease;

--- a/src-tauri/src/proxy/realtime.rs
+++ b/src-tauri/src/proxy/realtime.rs
@@ -486,6 +486,10 @@ pub(super) fn replace_incremental_input(payload: &mut Value, input: Vec<Value>) 
 }
 
 async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
+    // The HTTP upgrade body ends immediately, but the model session remains
+    // active until this future returns. Keep a separate lease for its full
+    // lifetime so a long quiet WebSocket cannot let the machine idle-sleep.
+    let _wake_lease = ctx.wake.begin_activity();
     let (mut tx, mut rx) = socket.split();
     // A non-cancel frame read while a turn is streaming (see the select! in
     // the turn loop) is parked here so the next iteration still handles it.

--- a/src-tauri/src/proxy/tests_characterization.rs
+++ b/src-tauri/src/proxy/tests_characterization.rs
@@ -1,5 +1,45 @@
 use super::*;
 use futures::StreamExt;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn model_routes_acquire_the_wake_lock_but_health_checks_do_not() {
+    let (wake, events) =
+        crate::wake_lock::recording_controller(crate::config::SleepPreventionMode::WhileActive);
+    wake.set_proxy_running(true);
+    let app = Router::new()
+        .route("/health", get(|| async { "ok" }))
+        .route("/v1/responses", post(|| async { "ok" }))
+        .layer(middleware::from_fn_with_state(wake, track_model_activity));
+
+    let health = app
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(health.status().is_success());
+    assert!(events.try_recv().is_err());
+
+    let response = app
+        .oneshot(
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    assert!(events
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .unwrap());
+}
 
 #[test]
 fn ws_origin_policy_allows_only_local_browser_origins_or_no_origin() {

--- a/src-tauri/src/proxy/tests_characterization.rs
+++ b/src-tauri/src/proxy/tests_characterization.rs
@@ -41,6 +41,38 @@ async fn model_routes_acquire_the_wake_lock_but_health_checks_do_not() {
         .unwrap());
 }
 
+#[tokio::test]
+async fn an_unmatched_path_does_not_hold_the_wake_lock_open() {
+    let (wake, events) =
+        crate::wake_lock::recording_controller(crate::config::SleepPreventionMode::WhileActive);
+    wake.set_proxy_running(true);
+    let app = Router::new()
+        .route("/v1/responses", post(|| async { "ok" }))
+        .layer(middleware::from_fn_with_state(wake, track_model_activity));
+
+    let missing = app
+        .oneshot(
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/v1/embeddings")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+    // The lease is taken before routing can report the miss, so the backend does
+    // acquire — but the 404 cancels it, so the release must follow immediately
+    // instead of the 15-minute grace window holding the lock open.
+    assert!(events
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .unwrap());
+    assert!(!events
+        .recv_timeout(std::time::Duration::from_secs(1))
+        .unwrap());
+}
+
 #[test]
 fn ws_origin_policy_allows_only_local_browser_origins_or_no_origin() {
     // A regression here lets arbitrary webpages reach a localhost proxy that

--- a/src-tauri/src/proxy/tests_keys.rs
+++ b/src-tauri/src/proxy/tests_keys.rs
@@ -63,6 +63,7 @@ fn test_ctx(key_pools: KeyPools) -> ProxyCtx {
         key_pools,
         client: reqwest::Client::new(),
         history: Arc::new(Mutex::new(WsHistory::new())),
+        wake: crate::wake_lock::WakeController::disabled(),
     }
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -457,10 +457,15 @@ mod tests {
     };
 
     #[tokio::test]
-    async fn sleep_prevention_mode_is_persisted_by_the_state_boundary() {
+    async fn sleep_prevention_mode_is_persisted_and_reaches_the_wake_thread() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("config.json");
-        let state = AppState::for_test(AppConfig::default(), path.clone());
+        // Nothing is acquired while the mode is Never, so the first event the
+        // backend reports is proof that `set_mode` crossed the channel.
+        let (wake, events) = crate::wake_lock::recording_controller(SleepPreventionMode::Never);
+        wake.set_proxy_running(true);
+        let mut state = AppState::for_test(AppConfig::default(), path.clone());
+        state.wake = wake;
 
         state
             .set_sleep_prevention(SleepPreventionMode::Always)
@@ -474,6 +479,9 @@ mod tests {
         let persisted: AppConfig =
             serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
         assert_eq!(persisted.sleep_prevention, SleepPreventionMode::Always);
+        assert!(events
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap());
     }
 
     #[tokio::test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -9,6 +9,7 @@ use crate::config::AppConfig;
 use crate::stats::RequestEntry;
 use crate::stats::{SharedStats, Stats};
 use serde::Serialize;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::sync::{oneshot, RwLock};
 
@@ -46,7 +47,8 @@ pub struct AppState {
     pub config: SharedConfig,
     pub stats: SharedStats,
     pub key_pools: crate::keypool::KeyPools,
-    server: RwLock<Option<ServerHandle>>,
+    server: Arc<RwLock<Option<ServerHandle>>>,
+    pub(crate) wake: crate::wake_lock::WakeController,
     /// Serializes the combined power toggle. Without it, two fast clicks on
     /// the tray item interleave start/stop with apply/remove and settle on a
     /// state neither click asked for.
@@ -78,16 +80,22 @@ pub struct AppState {
 }
 
 struct ServerHandle {
+    id: u64,
     shutdown: oneshot::Sender<()>,
 }
 
+static NEXT_SERVER_ID: AtomicU64 = AtomicU64::new(1);
+
 impl AppState {
     pub fn load() -> Self {
+        let config = AppConfig::load();
+        let wake = crate::wake_lock::WakeController::new(config.sleep_prevention);
         Self {
-            config: Arc::new(RwLock::new(AppConfig::load())),
+            config: Arc::new(RwLock::new(config)),
             stats: Arc::new(RwLock::new(Stats::load())),
             key_pools: crate::keypool::KeyPools::new(),
-            server: RwLock::new(None),
+            server: Arc::new(RwLock::new(None)),
+            wake,
             power: tokio::sync::Mutex::new(()),
             tool_import: tokio::sync::Mutex::new(()),
             model_contexts: RwLock::new(std::collections::HashMap::new()),
@@ -121,7 +129,8 @@ impl AppState {
             config: Arc::new(RwLock::new(config)),
             stats: Arc::new(RwLock::new(Stats::load())),
             key_pools: crate::keypool::KeyPools::new(),
-            server: RwLock::new(None),
+            server: Arc::new(RwLock::new(None)),
+            wake: crate::wake_lock::WakeController::disabled(),
             power: tokio::sync::Mutex::new(()),
             tool_import: tokio::sync::Mutex::new(()),
             model_contexts: RwLock::new(std::collections::HashMap::new()),
@@ -443,14 +452,57 @@ async fn fetch_balance(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Provider, ProviderKey, ProviderModel, ProviderProtocol};
+    use crate::config::{
+        Provider, ProviderKey, ProviderModel, ProviderProtocol, SleepPreventionMode,
+    };
+
+    #[tokio::test]
+    async fn sleep_prevention_mode_is_persisted_by_the_state_boundary() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let state = AppState::for_test(AppConfig::default(), path.clone());
+
+        state
+            .set_sleep_prevention(SleepPreventionMode::Always)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            state.config.read().await.sleep_prevention,
+            SleepPreventionMode::Always
+        );
+        let persisted: AppConfig =
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        assert_eq!(persisted.sleep_prevention, SleepPreventionMode::Always);
+    }
+
+    #[tokio::test]
+    async fn server_stop_keeps_wake_lock_until_graceful_drain_finishes() {
+        let (wake, events) = crate::wake_lock::recording_controller(SleepPreventionMode::Always);
+        wake.set_proxy_running(true);
+        assert!(events
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap());
+
+        let (shutdown, _) = tokio::sync::oneshot::channel::<()>();
+        let mut state = state_with_config(AppConfig::default());
+        state.wake = wake;
+        state.server = Arc::new(RwLock::new(Some(ServerHandle { id: 1, shutdown })));
+
+        state.server_stop().await.unwrap();
+
+        assert!(events
+            .recv_timeout(std::time::Duration::from_millis(50))
+            .is_err());
+    }
 
     fn state_with_config(config: AppConfig) -> AppState {
         AppState {
             config: Arc::new(RwLock::new(config)),
             stats: Arc::new(RwLock::new(Stats::load())),
             key_pools: crate::keypool::KeyPools::new(),
-            server: RwLock::new(None),
+            server: Arc::new(RwLock::new(None)),
+            wake: crate::wake_lock::WakeController::disabled(),
             power: tokio::sync::Mutex::new(()),
             tool_import: tokio::sync::Mutex::new(()),
             model_contexts: RwLock::new(std::collections::HashMap::new()),
@@ -1067,7 +1119,8 @@ mod tests {
             config: Arc::new(RwLock::new(AppConfig::default())),
             stats: Arc::new(RwLock::new(Stats::load())),
             key_pools: crate::keypool::KeyPools::new(),
-            server: RwLock::new(Some(ServerHandle { shutdown })),
+            server: Arc::new(RwLock::new(Some(ServerHandle { id: 1, shutdown }))),
+            wake: crate::wake_lock::WakeController::disabled(),
             power: tokio::sync::Mutex::new(()),
             tool_import: tokio::sync::Mutex::new(()),
             model_contexts: RwLock::new(std::collections::HashMap::new()),

--- a/src-tauri/src/state/lifecycle.rs
+++ b/src-tauri/src/state/lifecycle.rs
@@ -2,11 +2,13 @@
 
 use super::{
     codex_is_active, derive_setup_status, fetch_balance, model_discovery, AppConfig, AppState,
-    ProviderBalance, ServerHandle, ServerStatus, SetupStatus, SetupValidation, WIZARD_STEPS,
+    ProviderBalance, ServerHandle, ServerStatus, SetupStatus, SetupValidation, NEXT_SERVER_ID,
+    WIZARD_STEPS,
 };
 use crate::codex;
 use crate::config::VisualAssistanceConfig;
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::Ordering;
 use tokio::sync::oneshot;
 
 impl AppState {
@@ -420,21 +422,48 @@ impl AppState {
             return Ok(self.status_with(true).await);
         }
         let port = self.config.read().await.port;
-        let app = crate::proxy::router_with_pools(
+        let app = crate::proxy::router_with_pools_and_wake(
             self.config.clone(),
             self.stats.clone(),
             self.key_pools.clone(),
+            self.wake.clone(),
         );
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", port)).await?;
         let (tx, rx) = oneshot::channel::<()>();
+        let server_id = NEXT_SERVER_ID.fetch_add(1, Ordering::Relaxed);
+        let server = self.server.clone();
+        let wake = self.wake.clone();
         tokio::spawn(async move {
-            let _ = axum::serve(listener, app)
+            let result = axum::serve(listener, app)
                 .with_graceful_shutdown(async {
                     let _ = rx.await;
                 })
                 .await;
+            if let Err(error) = result {
+                tracing::error!(%error, "proxy server stopped unexpectedly");
+            }
+
+            let mut guard = server.write().await;
+            let owns_wake_lock = match guard.as_ref() {
+                Some(handle) if handle.id == server_id => {
+                    guard.take();
+                    true
+                }
+                None => true,
+                Some(_) => false,
+            };
+            if owns_wake_lock {
+                // Keep this send serialized with server_start's matching send,
+                // or an old task can disable a replacement server after it starts.
+                wake.set_proxy_running(false);
+            }
+            drop(guard);
         });
-        *guard = Some(ServerHandle { shutdown: tx });
+        *guard = Some(ServerHandle {
+            id: server_id,
+            shutdown: tx,
+        });
+        self.wake.set_proxy_running(true);
         tracing::info!(port, "proxy listening on 127.0.0.1");
         drop(guard);
         self.maybe_auto_apply().await;
@@ -683,6 +712,16 @@ impl AppState {
         self.config.write().await.native_slug_mode = enabled;
         self.persist().await?;
         self.maybe_auto_apply().await;
+        Ok(())
+    }
+
+    pub async fn set_sleep_prevention(
+        &self,
+        mode: crate::config::SleepPreventionMode,
+    ) -> anyhow::Result<()> {
+        self.config.write().await.sleep_prevention = mode;
+        self.persist().await?;
+        self.wake.set_mode(mode);
         Ok(())
     }
 

--- a/src-tauri/src/state/lifecycle.rs
+++ b/src-tauri/src/state/lifecycle.rs
@@ -719,8 +719,18 @@ impl AppState {
         &self,
         mode: crate::config::SleepPreventionMode,
     ) -> anyhow::Result<()> {
-        self.config.write().await.sleep_prevention = mode;
-        self.persist().await?;
+        let previous = {
+            let mut cfg = self.config.write().await;
+            let previous = cfg.sleep_prevention;
+            cfg.sleep_prevention = mode;
+            previous
+        };
+        // Roll the in-memory field back on a write failure, or the UI reports a
+        // mode the wake thread was never told about.
+        if let Err(error) = self.persist().await {
+            self.config.write().await.sleep_prevention = previous;
+            return Err(error);
+        }
         self.wake.set_mode(mode);
         Ok(())
     }

--- a/src-tauri/src/wake_lock.rs
+++ b/src-tauri/src/wake_lock.rs
@@ -2,14 +2,24 @@ use crate::config::SleepPreventionMode;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
+/// Changing this also means updating the "15 minutes" figure spelled out in
+/// `server.sleepPreventionHint` in `src/i18n/{en,pt,es,zh}.ts` — the hint is
+/// plain prose in each locale, so nothing else fails when they drift.
 pub(crate) const ACTIVITY_GRACE: Duration = Duration::from_secs(15 * 60);
 const ACQUIRE_RETRY: Duration = Duration::from_secs(5);
+/// Ceiling for the exponential retry backoff. A host that can never acquire —
+/// Linux with no system D-Bus, for instance — would otherwise re-attempt every
+/// `ACQUIRE_RETRY` for the whole process lifetime.
+const ACQUIRE_RETRY_MAX: Duration = Duration::from_secs(5 * 60);
 
 enum WakeCommand {
     SetMode(SleepPreventionMode),
     SetProxyRunning(bool),
     BeginActivity,
     EndActivity,
+    /// Like `EndActivity`, but without arming the idle grace: the request was
+    /// never model activity, so it must not extend the wake window.
+    CancelActivity,
 }
 
 trait WakeBackend: Send {
@@ -131,6 +141,16 @@ pub(crate) fn recording_controller(
     )
 }
 
+impl WakeLease {
+    /// Hand the lease back without arming the idle grace, for a request that
+    /// turned out not to be model activity (an unrouted path, say).
+    pub(crate) fn cancel(mut self) {
+        if let Some(tx) = self.tx.take() {
+            let _ = tx.send(WakeCommand::CancelActivity);
+        }
+    }
+}
+
 impl Drop for WakeLease {
     fn drop(&mut self) {
         if let Some(tx) = &self.tx {
@@ -148,6 +168,7 @@ fn run_controller(
 ) {
     let mut held = false;
     let mut retry_at = None;
+    let mut retry_backoff = retry;
     loop {
         let now = Instant::now();
         let should_hold = state.should_hold(now);
@@ -157,18 +178,29 @@ fn run_controller(
                 Ok(()) => {
                     held = true;
                     retry_at = None;
+                    retry_backoff = retry;
                 }
                 Err(error) => {
-                    retry_at = Some(now + retry);
-                    tracing::warn!(%error, "failed to prevent idle system sleep");
+                    // Back off toward ACQUIRE_RETRY_MAX and warn only once per
+                    // streak: a permanently unavailable backend is a standing
+                    // condition, not 17k separate incidents a day.
+                    if retry_at.is_none() {
+                        tracing::warn!(%error, "failed to prevent idle system sleep; retrying with backoff");
+                    } else {
+                        tracing::debug!(%error, "still cannot prevent idle system sleep");
+                    }
+                    retry_at = Some(now + retry_backoff);
+                    retry_backoff = (retry_backoff * 2).min(ACQUIRE_RETRY_MAX);
                 }
             }
         } else if !should_hold && held {
             backend.release();
             held = false;
             retry_at = None;
+            retry_backoff = retry;
         } else if !should_hold {
             retry_at = None;
+            retry_backoff = retry;
         }
 
         let deadline = [state.next_deadline(now), retry_at]
@@ -194,6 +226,7 @@ fn run_controller(
             WakeCommand::SetProxyRunning(running) => state.set_proxy_running(running),
             WakeCommand::BeginActivity => state.begin_activity(),
             WakeCommand::EndActivity => state.end_activity(Instant::now(), grace),
+            WakeCommand::CancelActivity => state.cancel_activity(),
         }
     }
 }
@@ -228,12 +261,27 @@ impl WakeState {
     }
 
     fn begin_activity(&mut self) {
+        // `idle_until` is deliberately left alone: `should_hold` ignores it
+        // while a request is in flight, and `end_activity` overwrites it on the
+        // way out. Clearing it here would let a cancelled lease — a 404 landing
+        // mid-grace — cut a live wake window short.
         self.active_requests = self.active_requests.saturating_add(1);
-        self.idle_until = None;
+    }
+
+    fn cancel_activity(&mut self) {
+        self.active_requests = self.active_requests.saturating_sub(1);
     }
 
     fn end_activity(&mut self, now: Instant, grace: Duration) {
         self.active_requests = self.active_requests.saturating_sub(1);
+        if !self.proxy_running {
+            // An upgraded WebSocket runs in a task `axum::serve` never awaits,
+            // so its lease can drop after the proxy already reported stopped.
+            // Arming the grace here would hand a wake lock to the next start
+            // with no traffic behind it.
+            self.idle_until = None;
+            return;
+        }
         if self.active_requests == 0 {
             self.idle_until = Some(now + grace);
         }
@@ -270,28 +318,9 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::time::{Duration, Instant};
 
-    struct ReportingBackend(mpsc::Sender<bool>);
-
-    impl WakeBackend for ReportingBackend {
-        fn acquire(&mut self) -> anyhow::Result<()> {
-            self.0.send(true).unwrap();
-            Ok(())
-        }
-
-        fn release(&mut self) {
-            self.0.send(false).unwrap();
-        }
-    }
-
     #[test]
     fn controller_applies_mode_changes_on_its_backend_thread() {
-        let (events_tx, events_rx) = mpsc::channel();
-        let controller = WakeController::with_backend(
-            SleepPreventionMode::Always,
-            Duration::from_secs(900),
-            Duration::from_secs(5),
-            Box::new(ReportingBackend(events_tx)),
-        );
+        let (controller, events_rx) = recording_controller(SleepPreventionMode::Always);
 
         controller.set_proxy_running(true);
         assert!(events_rx.recv_timeout(Duration::from_secs(1)).unwrap());
@@ -302,13 +331,7 @@ mod tests {
 
     #[test]
     fn an_activity_lease_keeps_the_backend_acquired_until_policy_changes() {
-        let (events_tx, events_rx) = mpsc::channel();
-        let controller = WakeController::with_backend(
-            SleepPreventionMode::WhileActive,
-            Duration::from_secs(900),
-            Duration::from_secs(5),
-            Box::new(ReportingBackend(events_tx)),
-        );
+        let (controller, events_rx) = recording_controller(SleepPreventionMode::WhileActive);
         controller.set_proxy_running(true);
 
         let _lease = controller.begin_activity();
@@ -403,6 +426,40 @@ mod tests {
         state.end_activity(now, Duration::from_secs(900));
 
         state.set_proxy_running(false);
+        state.set_proxy_running(true);
+        assert!(!state.should_hold(now));
+    }
+
+    #[test]
+    fn a_cancelled_lease_leaves_a_running_grace_window_intact() {
+        let now = Instant::now();
+        let mut state = WakeState::new(SleepPreventionMode::WhileActive);
+        state.set_proxy_running(true);
+        state.begin_activity();
+        state.end_activity(now, Duration::from_secs(900));
+
+        // An unrouted request two minutes later must not shorten the window the
+        // real request opened.
+        let later = now + Duration::from_secs(120);
+        state.begin_activity();
+        state.cancel_activity();
+
+        assert!(state.should_hold(later));
+        assert!(!state.should_hold(now + Duration::from_secs(900)));
+    }
+
+    #[test]
+    fn a_lease_dropped_after_the_proxy_stopped_does_not_arm_the_grace() {
+        let now = Instant::now();
+        let mut state = WakeState::new(SleepPreventionMode::WhileActive);
+        state.set_proxy_running(true);
+        state.begin_activity();
+
+        // A WebSocket session runs in a detached task, so its lease drops
+        // *after* the lifecycle task has already reported the proxy stopped.
+        state.set_proxy_running(false);
+        state.end_activity(now, Duration::from_secs(900));
+
         state.set_proxy_running(true);
         assert!(!state.should_hold(now));
     }

--- a/src-tauri/src/wake_lock.rs
+++ b/src-tauri/src/wake_lock.rs
@@ -1,0 +1,409 @@
+use crate::config::SleepPreventionMode;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+pub(crate) const ACTIVITY_GRACE: Duration = Duration::from_secs(15 * 60);
+const ACQUIRE_RETRY: Duration = Duration::from_secs(5);
+
+enum WakeCommand {
+    SetMode(SleepPreventionMode),
+    SetProxyRunning(bool),
+    BeginActivity,
+    EndActivity,
+}
+
+trait WakeBackend: Send {
+    fn acquire(&mut self) -> anyhow::Result<()>;
+    fn release(&mut self);
+}
+
+struct SystemWakeBackend {
+    lock: Option<keepawake::KeepAwake>,
+}
+
+impl WakeBackend for SystemWakeBackend {
+    fn acquire(&mut self) -> anyhow::Result<()> {
+        if self.lock.is_none() {
+            self.lock = Some(
+                keepawake::Builder::default()
+                    .display(false)
+                    .idle(true)
+                    .sleep(false)
+                    .reason("LoomRouter model activity")
+                    .app_name("LoomRouter")
+                    .app_reverse_domain("dev.loomrouter.app")
+                    .create()?,
+            );
+        }
+        Ok(())
+    }
+
+    fn release(&mut self) {
+        self.lock = None;
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct WakeController {
+    tx: Option<mpsc::Sender<WakeCommand>>,
+}
+
+impl WakeController {
+    pub(crate) fn new(mode: SleepPreventionMode) -> Self {
+        Self::with_backend(
+            mode,
+            ACTIVITY_GRACE,
+            ACQUIRE_RETRY,
+            Box::new(SystemWakeBackend { lock: None }),
+        )
+    }
+
+    pub(crate) fn disabled() -> Self {
+        Self { tx: None }
+    }
+
+    fn with_backend(
+        mode: SleepPreventionMode,
+        grace: Duration,
+        retry: Duration,
+        backend: Box<dyn WakeBackend>,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel();
+        std::thread::Builder::new()
+            .name("loom-wake-lock".into())
+            .spawn(move || run_controller(rx, WakeState::new(mode), grace, retry, backend))
+            .expect("wake lock thread");
+        Self { tx: Some(tx) }
+    }
+
+    pub(crate) fn set_mode(&self, mode: SleepPreventionMode) {
+        self.send(WakeCommand::SetMode(mode));
+    }
+
+    pub(crate) fn set_proxy_running(&self, running: bool) {
+        self.send(WakeCommand::SetProxyRunning(running));
+    }
+
+    pub(crate) fn begin_activity(&self) -> WakeLease {
+        self.send(WakeCommand::BeginActivity);
+        WakeLease {
+            tx: self.tx.clone(),
+        }
+    }
+
+    fn send(&self, command: WakeCommand) {
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(command);
+        }
+    }
+}
+
+pub(crate) struct WakeLease {
+    tx: Option<mpsc::Sender<WakeCommand>>,
+}
+
+#[cfg(test)]
+pub(crate) fn recording_controller(
+    mode: SleepPreventionMode,
+) -> (WakeController, mpsc::Receiver<bool>) {
+    struct ReportingBackend(mpsc::Sender<bool>);
+
+    impl WakeBackend for ReportingBackend {
+        fn acquire(&mut self) -> anyhow::Result<()> {
+            self.0.send(true).unwrap();
+            Ok(())
+        }
+
+        fn release(&mut self) {
+            self.0.send(false).unwrap();
+        }
+    }
+
+    let (events_tx, events_rx) = mpsc::channel();
+    (
+        WakeController::with_backend(
+            mode,
+            ACTIVITY_GRACE,
+            ACQUIRE_RETRY,
+            Box::new(ReportingBackend(events_tx)),
+        ),
+        events_rx,
+    )
+}
+
+impl Drop for WakeLease {
+    fn drop(&mut self) {
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(WakeCommand::EndActivity);
+        }
+    }
+}
+
+fn run_controller(
+    rx: mpsc::Receiver<WakeCommand>,
+    mut state: WakeState,
+    grace: Duration,
+    retry: Duration,
+    mut backend: Box<dyn WakeBackend>,
+) {
+    let mut held = false;
+    let mut retry_at = None;
+    loop {
+        let now = Instant::now();
+        let should_hold = state.should_hold(now);
+        let retry_due = retry_at.is_none_or(|deadline| now >= deadline);
+        if should_hold && !held && retry_due {
+            match backend.acquire() {
+                Ok(()) => {
+                    held = true;
+                    retry_at = None;
+                }
+                Err(error) => {
+                    retry_at = Some(now + retry);
+                    tracing::warn!(%error, "failed to prevent idle system sleep");
+                }
+            }
+        } else if !should_hold && held {
+            backend.release();
+            held = false;
+            retry_at = None;
+        } else if !should_hold {
+            retry_at = None;
+        }
+
+        let deadline = [state.next_deadline(now), retry_at]
+            .into_iter()
+            .flatten()
+            .min();
+        let command = match deadline {
+            Some(deadline) => match rx.recv_timeout(deadline.saturating_duration_since(now)) {
+                Ok(command) => Some(command),
+                Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(mpsc::RecvTimeoutError::Disconnected) => None,
+            },
+            None => rx.recv().ok(),
+        };
+        let Some(command) = command else {
+            if held {
+                backend.release();
+            }
+            break;
+        };
+        match command {
+            WakeCommand::SetMode(mode) => state.set_mode(mode),
+            WakeCommand::SetProxyRunning(running) => state.set_proxy_running(running),
+            WakeCommand::BeginActivity => state.begin_activity(),
+            WakeCommand::EndActivity => state.end_activity(Instant::now(), grace),
+        }
+    }
+}
+
+struct WakeState {
+    mode: SleepPreventionMode,
+    proxy_running: bool,
+    active_requests: usize,
+    idle_until: Option<Instant>,
+}
+
+impl WakeState {
+    fn new(mode: SleepPreventionMode) -> Self {
+        Self {
+            mode,
+            proxy_running: false,
+            active_requests: 0,
+            idle_until: None,
+        }
+    }
+
+    fn set_mode(&mut self, mode: SleepPreventionMode) {
+        self.mode = mode;
+    }
+
+    fn set_proxy_running(&mut self, running: bool) {
+        self.proxy_running = running;
+        if !running {
+            self.active_requests = 0;
+            self.idle_until = None;
+        }
+    }
+
+    fn begin_activity(&mut self) {
+        self.active_requests = self.active_requests.saturating_add(1);
+        self.idle_until = None;
+    }
+
+    fn end_activity(&mut self, now: Instant, grace: Duration) {
+        self.active_requests = self.active_requests.saturating_sub(1);
+        if self.active_requests == 0 {
+            self.idle_until = Some(now + grace);
+        }
+    }
+
+    fn should_hold(&self, now: Instant) -> bool {
+        if !self.proxy_running {
+            return false;
+        }
+        match self.mode {
+            SleepPreventionMode::Never => false,
+            SleepPreventionMode::Always => true,
+            SleepPreventionMode::WhileActive => {
+                self.active_requests > 0 || self.idle_until.is_some_and(|until| now < until)
+            }
+        }
+    }
+
+    fn next_deadline(&self, now: Instant) -> Option<Instant> {
+        (self.proxy_running
+            && self.mode == SleepPreventionMode::WhileActive
+            && self.active_requests == 0)
+            .then_some(self.idle_until)
+            .flatten()
+            .filter(|deadline| *deadline >= now)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SleepPreventionMode;
+    use std::sync::mpsc;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    struct ReportingBackend(mpsc::Sender<bool>);
+
+    impl WakeBackend for ReportingBackend {
+        fn acquire(&mut self) -> anyhow::Result<()> {
+            self.0.send(true).unwrap();
+            Ok(())
+        }
+
+        fn release(&mut self) {
+            self.0.send(false).unwrap();
+        }
+    }
+
+    #[test]
+    fn controller_applies_mode_changes_on_its_backend_thread() {
+        let (events_tx, events_rx) = mpsc::channel();
+        let controller = WakeController::with_backend(
+            SleepPreventionMode::Always,
+            Duration::from_secs(900),
+            Duration::from_secs(5),
+            Box::new(ReportingBackend(events_tx)),
+        );
+
+        controller.set_proxy_running(true);
+        assert!(events_rx.recv_timeout(Duration::from_secs(1)).unwrap());
+
+        controller.set_mode(SleepPreventionMode::Never);
+        assert!(!events_rx.recv_timeout(Duration::from_secs(1)).unwrap());
+    }
+
+    #[test]
+    fn an_activity_lease_keeps_the_backend_acquired_until_policy_changes() {
+        let (events_tx, events_rx) = mpsc::channel();
+        let controller = WakeController::with_backend(
+            SleepPreventionMode::WhileActive,
+            Duration::from_secs(900),
+            Duration::from_secs(5),
+            Box::new(ReportingBackend(events_tx)),
+        );
+        controller.set_proxy_running(true);
+
+        let _lease = controller.begin_activity();
+        assert!(events_rx.recv_timeout(Duration::from_secs(1)).unwrap());
+
+        controller.set_mode(SleepPreventionMode::Never);
+        assert!(!events_rx.recv_timeout(Duration::from_secs(1)).unwrap());
+    }
+
+    #[test]
+    fn acquisition_failure_is_retried_without_another_command() {
+        struct FailsOnceBackend {
+            attempts: Arc<Mutex<usize>>,
+            acquired: mpsc::Sender<()>,
+        }
+
+        impl WakeBackend for FailsOnceBackend {
+            fn acquire(&mut self) -> anyhow::Result<()> {
+                let mut attempts = self.attempts.lock().unwrap();
+                *attempts += 1;
+                if *attempts == 1 {
+                    anyhow::bail!("temporary platform failure");
+                }
+                self.acquired.send(()).unwrap();
+                Ok(())
+            }
+
+            fn release(&mut self) {}
+        }
+
+        let attempts = Arc::new(Mutex::new(0));
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+        let controller = WakeController::with_backend(
+            SleepPreventionMode::Always,
+            Duration::from_secs(900),
+            Duration::from_millis(10),
+            Box::new(FailsOnceBackend {
+                attempts: attempts.clone(),
+                acquired: acquired_tx,
+            }),
+        );
+
+        controller.set_proxy_running(true);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert_eq!(*attempts.lock().unwrap(), 2);
+    }
+
+    #[test]
+    fn activity_mode_holds_during_a_request_and_for_the_grace_period() {
+        let now = Instant::now();
+        let mut state = WakeState::new(SleepPreventionMode::WhileActive);
+        state.set_proxy_running(true);
+
+        state.begin_activity();
+        assert!(state.should_hold(now));
+
+        state.end_activity(now, Duration::from_secs(900));
+        assert!(state.should_hold(now + Duration::from_secs(899)));
+        assert!(!state.should_hold(now + Duration::from_secs(900)));
+    }
+
+    #[test]
+    fn always_mode_follows_the_proxy_instead_of_request_activity() {
+        let now = Instant::now();
+        let mut state = WakeState::new(SleepPreventionMode::Always);
+
+        assert!(!state.should_hold(now));
+        state.set_proxy_running(true);
+        assert!(state.should_hold(now));
+        state.set_proxy_running(false);
+        assert!(!state.should_hold(now));
+    }
+
+    #[test]
+    fn never_mode_releases_even_with_an_active_request() {
+        let now = Instant::now();
+        let mut state = WakeState::new(SleepPreventionMode::WhileActive);
+        state.set_proxy_running(true);
+        state.begin_activity();
+        assert!(state.should_hold(now));
+
+        state.set_mode(SleepPreventionMode::Never);
+        assert!(!state.should_hold(now));
+    }
+
+    #[test]
+    fn stopping_the_proxy_clears_stale_activity() {
+        let now = Instant::now();
+        let mut state = WakeState::new(SleepPreventionMode::WhileActive);
+        state.set_proxy_running(true);
+        state.begin_activity();
+        state.end_activity(now, Duration::from_secs(900));
+
+        state.set_proxy_running(false);
+        state.set_proxy_running(true);
+        assert!(!state.should_hold(now));
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "LoomRouter",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "identifier": "dev.loomrouter.app",
   "build": {
     "beforeDevCommand": "bun run dev",

--- a/src-tauri/tests/claude_stream.rs
+++ b/src-tauri/tests/claude_stream.rs
@@ -76,8 +76,15 @@ printf '%s\n' '{result}'
 
 /// A stand-in `claude` implemented as a Windows batch script. Same three
 /// modes as the Unix helper: slow answers with delays, fast answers
-/// immediately, fail exits non-zero. `timeout /t` replaces `sleep` (minimum
-/// 1s, close enough to the Unix sleep 1).
+/// immediately, fail exits non-zero.
+///
+/// `ping -n` stands in for `sleep`, not `timeout /t`: the turn's prompt is
+/// piped into this script's stdin, and `timeout` refuses to run at all under
+/// redirected input ("ERROR: Input redirection is not supported"), returning
+/// instantly. That made the slow mode indistinguishable from the fast one, so
+/// the streaming assertion below failed on Windows no matter how the bridge
+/// behaved. `ping -n 2` waits ~1s between its two probes; `ping -n 1` returns
+/// at once and keeps the no-delay branch a syntactically valid command.
 #[cfg(windows)]
 fn install_fake_cli(dir: &std::path::Path) -> std::path::PathBuf {
     let script = dir.join("fake-claude.cmd");
@@ -95,12 +102,12 @@ if "%mode%"=="fail" (
   echo boom 1>&2
   exit /b 3
 )
-set gap=0
-if "%mode%"=="slow" set gap=1
+set nap=ping -n 1 127.0.0.1
+if "%mode%"=="slow" set nap=ping -n 2 127.0.0.1
 echo({assistant_one}
-timeout /t %gap% /nobreak > nul
+%nap% > nul
 echo({assistant_two}
-timeout /t %gap% /nobreak > nul
+%nap% > nul
 echo({result}
 "#,
         dir = dir.display(),

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -186,6 +186,11 @@ const en = {
     noProviderTraffic: 'No per-provider traffic yet.',
     provider: 'Provider',
     attentionErrors: '{{count}} errors in the last 24h',
+    sleepPrevention: 'Prevent computer sleep',
+    sleepDuringActivity: 'During model activity',
+    sleepWhileOn: 'While Loom is on',
+    sleepNever: 'Never',
+    sleepPreventionHint: 'Activity mode covers requests, WebSockets, and 15 minutes after. The display may still turn off.',
   },
   codex: {
     title: 'Codex Integration',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -184,6 +184,11 @@ const es: DeepPartial<Strings> = {
     noProviderTraffic: 'Aún no hay tráfico por proveedor.',
     provider: 'Proveedor',
     attentionErrors: '{{count}} errores en las últimas 24 h',
+    sleepPrevention: 'Impedir la suspensión del equipo',
+    sleepDuringActivity: 'Durante la actividad de los modelos',
+    sleepWhileOn: 'Mientras Loom esté encendido',
+    sleepNever: 'Nunca',
+    sleepPreventionHint: 'El modo de actividad cubre solicitudes, WebSockets y 15 minutos más. La pantalla aún puede apagarse.',
   },
   codex: {
     title: 'Integración con Codex',

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -183,6 +183,11 @@ const pt: DeepPartial<Strings> = {
     noProviderTraffic: 'Nenhum tráfego por provedor ainda.',
     provider: 'Provedor',
     attentionErrors: '{{count}} erros nas últimas 24h',
+    sleepPrevention: 'Impedir suspensão do computador',
+    sleepDuringActivity: 'Durante atividade dos modelos',
+    sleepWhileOn: 'Enquanto o Loom estiver ligado',
+    sleepNever: 'Nunca',
+    sleepPreventionHint: 'O modo de atividade cobre requisições, WebSockets e mais 15 minutos. A tela ainda pode apagar.',
   },
   codex: {
     title: 'Integração com Codex',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -182,6 +182,11 @@ const zh: DeepPartial<Strings> = {
     noProviderTraffic: '还没有按服务商统计的流量。',
     provider: '服务商',
     attentionErrors: '最近 24 小时有 {{count}} 个错误',
+    sleepPrevention: '防止电脑休眠',
+    sleepDuringActivity: '模型活动期间',
+    sleepWhileOn: 'Loom 开启期间',
+    sleepNever: '从不',
+    sleepPreventionHint: '活动模式覆盖请求、WebSocket 及之后 15 分钟。显示器仍可关闭。',
   },
   codex: {
     title: 'Codex 集成',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,7 +2,7 @@
 // When running in a plain browser (bun run dev without Tauri), falls back
 // to an in-memory mock so the UI stays previewable.
 
-import type { AgentInfo, AgentTemplate, AppConfig, ClaudeAuthStatus, CodexStatus, ContextWindow, Provider, ProviderBalance, ProviderProtocol, RequestEntry, ServerStatus, SetupStatus, StatsSummary, ToolDetection, VisualAssistanceConfig, WizardStep } from '@/types'
+import type { AgentInfo, AgentTemplate, AppConfig, ClaudeAuthStatus, CodexStatus, ContextWindow, Provider, ProviderBalance, ProviderProtocol, RequestEntry, ServerStatus, SetupStatus, SleepPreventionMode, StatsSummary, ToolDetection, VisualAssistanceConfig, WizardStep } from '@/types'
 
 const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 
@@ -22,6 +22,7 @@ const mockState = {
     side_call_fallback: null,
     visual_assistance: { enabled: false, assistant_model: null, fallback_models: [] },
     native_slug_mode: false,
+    sleep_prevention: 'while_active' as SleepPreventionMode,
     native_model_context_overrides: {},
     active_model: 'kimi-coding/k3',
     // The browser preview shows the app itself; flip this to undefined to
@@ -443,6 +444,10 @@ function mock<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
     case 'set_native_slug_mode':
       mockState.config.native_slug_mode = (args?.enabled as boolean) ?? false
       return Promise.resolve(undefined as T)
+    case 'set_sleep_prevention':
+      mockState.config.sleep_prevention =
+        (args?.mode as SleepPreventionMode) ?? 'while_active'
+      return Promise.resolve(undefined as T)
     case 'set_native_model_context_override':
       mockState.config.native_model_context_overrides[args?.model as string] =
         args?.contextWindow as number
@@ -625,6 +630,8 @@ export const api = {
   setMultiAgent: (enabled: boolean) => call<boolean>('set_multi_agent', { enabled }),
   setSideCallFallback: (model: string | null) => call<void>('set_side_call_fallback', { model }),
   setNativeSlugMode: (enabled: boolean) => call<void>('set_native_slug_mode', { enabled }),
+  setSleepPrevention: (mode: SleepPreventionMode) =>
+    call<void>('set_sleep_prevention', { mode }),
   setNativeModelContextOverride: (model: string, contextWindow: number) =>
     call<void>('set_native_model_context_override', { model, contextWindow }),
   clearNativeModelContextOverride: (model: string) =>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,6 +3,7 @@
 // to an in-memory mock so the UI stays previewable.
 
 import type { AgentInfo, AgentTemplate, AppConfig, ClaudeAuthStatus, CodexStatus, ContextWindow, Provider, ProviderBalance, ProviderProtocol, RequestEntry, ServerStatus, SetupStatus, SleepPreventionMode, StatsSummary, ToolDetection, VisualAssistanceConfig, WizardStep } from '@/types'
+import { SLEEP_PREVENTION_DEFAULT } from '@/types'
 
 const isTauri = typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window
 
@@ -22,7 +23,7 @@ const mockState = {
     side_call_fallback: null,
     visual_assistance: { enabled: false, assistant_model: null, fallback_models: [] },
     native_slug_mode: false,
-    sleep_prevention: 'while_active' as SleepPreventionMode,
+    sleep_prevention: SLEEP_PREVENTION_DEFAULT,
     native_model_context_overrides: {},
     active_model: 'kimi-coding/k3',
     // The browser preview shows the app itself; flip this to undefined to
@@ -446,7 +447,7 @@ function mock<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
       return Promise.resolve(undefined as T)
     case 'set_sleep_prevention':
       mockState.config.sleep_prevention =
-        (args?.mode as SleepPreventionMode) ?? 'while_active'
+        (args?.mode as SleepPreventionMode) ?? SLEEP_PREVENTION_DEFAULT
       return Promise.resolve(undefined as T)
     case 'set_native_model_context_override':
       mockState.config.native_model_context_overrides[args?.model as string] =

--- a/src/pages/Server.test.tsx
+++ b/src/pages/Server.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import type { StatsSummary } from '@/types'
 
@@ -35,6 +36,7 @@ const statsSummary = vi.hoisted(() => vi.fn<() => Promise<StatsSummary>>(async (
     },
   ],
 })))
+const setSleepPrevention = vi.hoisted(() => vi.fn(async () => {}))
 
 vi.mock('@/lib/events', () => ({ useBackendState: () => {} }))
 
@@ -77,6 +79,7 @@ vi.mock('@/lib/api', () => ({
         },
         side_call_fallback: null,
         native_slug_mode: false,
+        sleep_prevention: 'while_active',
         onboarding_completed: true,
       }),
     codexStatus: () =>
@@ -103,12 +106,29 @@ vi.mock('@/lib/api', () => ({
       }),
     serverStart: () => Promise.resolve(),
     serverStop: () => Promise.resolve(),
+    setSleepPrevention,
   },
 }))
 
 import ServerPage from './Server'
 
 describe('Server page', () => {
+  it('lets the user keep the computer awake whenever the proxy is running', async () => {
+    setSleepPrevention.mockClear()
+    const user = userEvent.setup()
+    render(<ServerPage />)
+
+    const select = await screen.findByRole('combobox', { name: 'Prevent computer sleep' })
+    expect(screen.getByText('During model activity')).toBeVisible()
+
+    await user.click(select)
+    await user.click(screen.getByRole('option', { name: 'While Loom is on' }))
+
+    await waitFor(() => {
+      expect(setSleepPrevention).toHaveBeenCalledWith('always')
+    })
+  })
+
   it('shows proxy connection, integration and traffic conclusions', async () => {
     render(<ServerPage />)
 

--- a/src/pages/Server.tsx
+++ b/src/pages/Server.tsx
@@ -4,6 +4,7 @@ import { api } from '@/lib/api'
 import { useBackendState } from '@/lib/events'
 import { useStrings } from '@/i18n'
 import type { AppConfig, CodexStatus, ServerStatus, SleepPreventionMode, StatsSummary } from '@/types'
+import { SLEEP_PREVENTION_DEFAULT } from '@/types'
 import PageShell from '@/components/PageShell'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -122,7 +123,7 @@ export default function ServerPage() {
 
   const start = async () => setStatus(await api.serverStart())
   const stop = async () => setStatus(await api.serverStop())
-  const sleepPrevention = config?.sleep_prevention ?? 'while_active'
+  const sleepPrevention = config?.sleep_prevention ?? SLEEP_PREVENTION_DEFAULT
   const setSleepPrevention = async (mode: SleepPreventionMode) => {
     await api.setSleepPrevention(mode)
     setConfig((current) => current ? { ...current, sleep_prevention: mode } : current)

--- a/src/pages/Server.tsx
+++ b/src/pages/Server.tsx
@@ -3,11 +3,12 @@ import { Activity, AlertTriangle, Boxes, CheckCircle2, Play, ShieldCheck, Square
 import { api } from '@/lib/api'
 import { useBackendState } from '@/lib/events'
 import { useStrings } from '@/i18n'
-import type { AppConfig, CodexStatus, ServerStatus, StatsSummary } from '@/types'
+import type { AppConfig, CodexStatus, ServerStatus, SleepPreventionMode, StatsSummary } from '@/types'
 import PageShell from '@/components/PageShell'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 
 const DAY_SECS = 86_400
 
@@ -121,6 +122,11 @@ export default function ServerPage() {
 
   const start = async () => setStatus(await api.serverStart())
   const stop = async () => setStatus(await api.serverStop())
+  const sleepPrevention = config?.sleep_prevention ?? 'while_active'
+  const setSleepPrevention = async (mode: SleepPreventionMode) => {
+    await api.setSleepPrevention(mode)
+    setConfig((current) => current ? { ...current, sleep_prevention: mode } : current)
+  }
 
   const enabledProviders = useMemo(
     () => Object.values(config?.providers ?? {}).filter((provider) => provider.enabled).length,
@@ -258,6 +264,25 @@ export default function ServerPage() {
                   {config?.active_model ?? s.codex.activeModelOff}
                 </span>
               </div>
+            </div>
+            <div className="space-y-2 border-t border-border pt-3">
+              <label className="text-sm font-medium" htmlFor="sleep-prevention">
+                {s.server.sleepPrevention}
+              </label>
+              <Select
+                value={sleepPrevention}
+                onValueChange={(value) => void setSleepPrevention(value as SleepPreventionMode)}
+              >
+                <SelectTrigger id="sleep-prevention" aria-label={s.server.sleepPrevention}>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="while_active">{s.server.sleepDuringActivity}</SelectItem>
+                  <SelectItem value="always">{s.server.sleepWhileOn}</SelectItem>
+                  <SelectItem value="never">{s.server.sleepNever}</SelectItem>
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">{s.server.sleepPreventionHint}</p>
             </div>
             {status?.running ? (
               <Button variant="outline" onClick={stop}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 // LoomRouter shared types (mirror of src-tauri Rust structs).
 
 export type ProviderProtocol = 'openai' | 'anthropic' | 'responses'
+export type SleepPreventionMode = 'never' | 'while_active' | 'always'
 
 export interface ProviderKey {
   id: string
@@ -75,6 +76,7 @@ export interface AppConfig {
   // When true, external models are exposed as native slugs so Codex can be
   // used without an OpenAI login.
   native_slug_mode: boolean
+  sleep_prevention?: SleepPreventionMode
   // Explicit catalog windows for native Codex model slugs.
   native_model_context_overrides: Record<string, number>
   // Model Codex starts new sessions with, as "provider/model"; null leaves

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,9 @@
 
 export type ProviderProtocol = 'openai' | 'anthropic' | 'responses'
 export type SleepPreventionMode = 'never' | 'while_active' | 'always'
+// Mirrors `#[default] WhileActive` on the Rust enum. Kept here so the value the
+// UI shows before the config loads cannot drift from what the backend applies.
+export const SLEEP_PREVENTION_DEFAULT: SleepPreventionMode = 'while_active'
 
 export interface ProviderKey {
   id: string
@@ -76,7 +79,7 @@ export interface AppConfig {
   // When true, external models are exposed as native slugs so Codex can be
   // used without an OpenAI login.
   native_slug_mode: boolean
-  sleep_prevention?: SleepPreventionMode
+  sleep_prevention: SleepPreventionMode
   // Explicit catalog windows for native Codex model slugs.
   native_model_context_overrides: Record<string, number>
   // Model Codex starts new sessions with, as "provider/model"; null leaves


### PR DESCRIPTION
## Summary

- add configurable sleep prevention modes: during model activity, while Loom is on, and never
- keep HTTP streams and realtime WebSocket sessions awake, with a 15-minute activity grace period
- prevent idle system sleep without forcing the display to stay on
- use native cross-platform inhibition through keepawake, with retry after transient acquisition failures
- preserve the wake lock through graceful draining and make proxy lifecycle restarts generation-safe
- expose the setting in the server screen with EN, PT, ES, and ZH translations
- bump the application version to 0.2.12 across package, Cargo, lockfile, and Tauri config

## Validation

- bun run lint
- bun run test (177 passed)
- bun run build
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path src-tauri/Cargo.toml (483 passed)
- macOS assertion verified manually: PreventUserIdleSystemSleep active, display sleep unchanged
- independent concurrency and cross-platform review completed with no remaining findings