### PR TITLE
fix(codex): merge Codex's full model schema into merged-models.json

### DIFF
--- a/src-tauri/src/codex.rs
+++ b/src-tauri/src/codex.rs
@@ -123,7 +123,16 @@ pub fn status(config: &AppConfig) -> CodexStatus {
         .and_then(|c| c.get("models").and_then(Value::as_array).map(Vec::len))
         .unwrap_or(0);
     let session = codex_session_status(&home.join("auth.json"));
-    let (codex_config_loads, codex_config_error) = catalog::validate_merged_catalog();
+    let merged_catalog_present = merged_catalog_path().exists();
+    // `codex doctor` is a subprocess with a 10s ceiling on every screen open.
+    // There is nothing to validate until the integration has published a
+    // catalog, so do not pay for it on the onboarding path.
+    let (codex_config_loads, codex_config_error) =
+        if merged_catalog_present && config.codex_integration {
+            catalog::validate_merged_catalog()
+        } else {
+            (false, None)
+        };
     CodexStatus {
         codex_home: home.display().to_string(),
         config_exists: cfg_path.exists(),
@@ -131,7 +140,7 @@ pub fn status(config: &AppConfig) -> CodexStatus {
         managed_block_present: raw.contains(BEGIN_MARK),
         managed_block_orphaned: raw.contains(BEGIN_MARK) && !raw.contains(END_MARK),
         native_catalog_present: native_catalog_path().exists(),
-        merged_catalog_present: merged_catalog_path().exists(),
+        merged_catalog_present,
         merged_model_count: count,
         codex_cli_available: codex_bin().is_some(),
         codex_config_loads,
@@ -493,7 +502,8 @@ fn bundled_desktop_cli() -> Option<String> {
 #[path = "codex/catalog.rs"]
 mod catalog;
 pub use catalog::{
-    build_merged_catalog, capture_native_catalog, context_window_for, ContextWindow,
+    build_merged_catalog, capture_native_catalog, context_window_for,
+    invalidate_merged_catalog_validation, ContextWindow,
 };
 use catalog::{load_native_catalog, loom_dir, merged_catalog_path, native_catalog_path};
 

--- a/src-tauri/src/codex.rs
+++ b/src-tauri/src/codex.rs
@@ -75,6 +75,10 @@ pub struct CodexStatus {
     pub merged_catalog_present: bool,
     pub merged_model_count: usize,
     pub codex_cli_available: bool,
+    /// Whether `codex doctor` can load the current merged catalog.
+    pub codex_config_loads: bool,
+    /// Human-readable reason when `codex_config_loads` is false.
+    pub codex_config_error: Option<String>,
     /// Whether auto-apply is on (user clicked Apply at least once).
     pub integration_enabled: bool,
     /// Presence and expiry of the local Codex session, never its token.
@@ -119,6 +123,7 @@ pub fn status(config: &AppConfig) -> CodexStatus {
         .and_then(|c| c.get("models").and_then(Value::as_array).map(Vec::len))
         .unwrap_or(0);
     let session = codex_session_status(&home.join("auth.json"));
+    let (codex_config_loads, codex_config_error) = catalog::validate_merged_catalog();
     CodexStatus {
         codex_home: home.display().to_string(),
         config_exists: cfg_path.exists(),
@@ -129,6 +134,8 @@ pub fn status(config: &AppConfig) -> CodexStatus {
         merged_catalog_present: merged_catalog_path().exists(),
         merged_model_count: count,
         codex_cli_available: codex_bin().is_some(),
+        codex_config_loads,
+        codex_config_error,
         integration_enabled: config.codex_integration,
         session,
     }

--- a/src-tauri/src/codex/catalog.rs
+++ b/src-tauri/src/codex/catalog.rs
@@ -19,20 +19,62 @@ pub(super) fn native_catalog_path() -> PathBuf {
     loom_dir().join("native-models.json")
 }
 
-/// Capture the native catalog from Codex Desktop's `models_cache.json` when
-/// available, falling back to the Codex CLI (`codex debug models`, then
-/// `--bundled`). Returns the parsed `{models: [...]}`.
+/// Capture the native catalog, preferring Codex Desktop's `models_cache.json`
+/// (the only source carrying the full model schema) and reconciling it against
+/// the Codex CLI (`codex debug models`, then `--bundled`) so slugs the cache
+/// has not picked up yet still land. Returns the parsed `{models: [...]}`.
 /// `exclude_slugs` lists additional slugs to drop (besides the built-in
 /// `provider/model` filter): in native slug mode our republished bare slugs
 /// echo back through `debug models` and must not pollute the next capture.
 pub fn capture_native_catalog(
     exclude_slugs: &std::collections::HashSet<String>,
 ) -> anyhow::Result<Value> {
-    if let Some(cached) = read_models_cache(exclude_slugs) {
-        persist_native_catalog(&cached)?;
-        return Ok(cached);
-    }
+    let cached = read_models_cache(exclude_slugs);
+    let from_cli = capture_cli_catalog(exclude_slugs);
+    let catalog = match (cached, from_cli) {
+        // The cache carries Codex's full model schema but only refreshes when
+        // Codex itself runs; `debug models` is stripped but always current.
+        // Keep the cache entry for every slug it knows and append the ones
+        // only the CLI reports, so a cache that predates a model release
+        // cannot pin the picker to the old set.
+        (Some(mut cache), Ok(cli)) => {
+            merge_cli_only_models(&mut cache, &cli);
+            ensure_native_catalog_backfills(&mut cache);
+            cache
+        }
+        (Some(cache), Err(_)) => cache,
+        (None, cli) => cli?,
+    };
+    persist_native_catalog(&catalog)?;
+    Ok(catalog)
+}
 
+/// Append the models the CLI reports that the cache does not know about.
+fn merge_cli_only_models(cache: &mut Value, cli: &Value) {
+    let known: std::collections::HashSet<String> = cache
+        .get("models")
+        .and_then(Value::as_array)
+        .map(|models| {
+            models
+                .iter()
+                .filter_map(|m| m.get("slug").and_then(Value::as_str))
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let Some(target) = cache.get_mut("models").and_then(Value::as_array_mut) else {
+        return;
+    };
+    let extras = cli.get("models").and_then(Value::as_array);
+    for model in extras.into_iter().flatten() {
+        match model.get("slug").and_then(Value::as_str) {
+            Some(slug) if !known.contains(slug) => target.push(model.clone()),
+            _ => {}
+        }
+    }
+}
+
+fn capture_cli_catalog(exclude_slugs: &std::collections::HashSet<String>) -> anyhow::Result<Value> {
     let bin = codex_bin().ok_or_else(|| {
         anyhow::anyhow!("Codex CLI not found on PATH (set CODEX_BIN to its location)")
     })?;
@@ -58,9 +100,7 @@ pub fn capture_native_catalog(
     };
     let raw = run("").or_else(|_| run("--bundled"))?;
     let parsed: Value = serde_json::from_str(&raw)?;
-    let catalog = native_catalog_from_value(parsed, exclude_slugs)?;
-    persist_native_catalog(&catalog)?;
-    Ok(catalog)
+    native_catalog_from_value(parsed, exclude_slugs)
 }
 
 fn read_models_cache(exclude_slugs: &std::collections::HashSet<String>) -> Option<Value> {
@@ -127,11 +167,18 @@ const CONFIG_LOAD_VALIDATION_TTL: Duration = Duration::from_secs(30);
 const CONFIG_LOAD_DOCTOR_TIMEOUT: Duration = Duration::from_secs(10);
 static CONFIG_LOAD_VALIDATION: Mutex<Option<(Instant, bool, Option<String>)>> = Mutex::new(None);
 
-#[cfg(test)]
-pub(crate) fn reset_validate_merged_catalog_cache() {
+/// Drop the cached verdict. Apply and remove rewrite the merged catalog, so
+/// the next status probe must re-run `codex doctor` instead of reporting the
+/// pre-change state for the rest of the TTL.
+pub fn invalidate_merged_catalog_validation() {
     *CONFIG_LOAD_VALIDATION
         .lock()
         .unwrap_or_else(|p| p.into_inner()) = None;
+}
+
+#[cfg(test)]
+pub(crate) fn reset_validate_merged_catalog_cache() {
+    invalidate_merged_catalog_validation();
 }
 
 /// Run `codex doctor` and report whether the merged catalog is loadable.
@@ -158,26 +205,56 @@ pub fn validate_merged_catalog() -> (bool, Option<String>) {
     result
 }
 
+/// `codex doctor` postdates some Codex CLI builds. A CLI that does not know
+/// the subcommand tells us nothing about the catalog, so fall back to the
+/// file-presence signal rather than painting a working integration red.
+fn doctor_unsupported(output: &DoctorOutput) -> bool {
+    let text = format!("{} {}", output.stdout, output.stderr).to_ascii_lowercase();
+    [
+        "unrecognized subcommand",
+        "unknown subcommand",
+        "invalid subcommand",
+        "unrecognized command",
+        "unknown command",
+    ]
+    .iter()
+    .any(|marker| text.contains(marker))
+}
+
+/// The first line that opens an `error:` diagnostic. Matching the bare
+/// substring anywhere flags healthy output (`0 errors, 0 warnings`) and any
+/// echoed path that happens to contain the word.
+fn first_error_line(stdout: &str) -> Option<&str> {
+    stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| line.to_ascii_lowercase().starts_with("error:"))
+}
+
 fn run_validate_merged_catalog() -> (bool, Option<String>) {
     let Some(bin) = codex_bin() else {
         return (false, Some("codex CLI not found".to_string()));
     };
     match run_codex_doctor(&bin) {
+        Ok(Some(output)) if doctor_unsupported(&output) => (merged_catalog_path().exists(), None),
         Ok(Some(output))
-            if output.status.success() && !output.stdout.to_ascii_lowercase().contains("error") =>
+            if output.status.success() && first_error_line(&output.stdout).is_none() =>
         {
             (true, None)
         }
         Ok(Some(output)) => {
-            let error = output.stderr.trim().to_string();
-            (
-                false,
-                Some(if error.is_empty() {
-                    "codex doctor reported an error".to_string()
-                } else {
-                    error
-                }),
-            )
+            // Prefer stderr, but a doctor that exits 0 and complains on stdout
+            // leaves stderr empty - report the offending line instead of
+            // dropping the one detail that says what to fix.
+            let stderr = output.stderr.trim();
+            let detail = if !stderr.is_empty() {
+                stderr.to_string()
+            } else if let Some(line) = first_error_line(&output.stdout) {
+                line.to_string()
+            } else {
+                "codex doctor reported an error".to_string()
+            };
+            (false, Some(detail))
         }
         Ok(None) => (false, Some("codex doctor timed out".to_string())),
         Err(e) => (false, Some(e.to_string())),
@@ -221,7 +298,18 @@ fn run_codex_doctor(bin: &str) -> std::io::Result<Option<DoctorOutput>> {
 
     let deadline = Instant::now() + CONFIG_LOAD_DOCTOR_TIMEOUT;
     loop {
-        match child.try_wait()? {
+        // A failed `try_wait` must not drop `child` still running: kill and
+        // reap it like the timeout branch does, or every failing status probe
+        // orphans a `codex doctor` and its two reader threads.
+        let waited = match child.try_wait() {
+            Ok(waited) => waited,
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(e);
+            }
+        };
+        match waited {
             Some(status) => {
                 let stdout = stdout_thread
                     .join()

--- a/src-tauri/src/codex/catalog.rs
+++ b/src-tauri/src/codex/catalog.rs
@@ -1,7 +1,11 @@
 use super::{codex_bin, codex_home};
 use crate::config::AppConfig;
 use serde_json::{json, Map, Value};
+use std::io::Read;
 use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 pub(super) fn loom_dir() -> PathBuf {
     codex_home().join("loom-router")
@@ -15,14 +19,20 @@ pub(super) fn native_catalog_path() -> PathBuf {
     loom_dir().join("native-models.json")
 }
 
-/// Capture the native catalog from the Codex CLI (`codex debug models`,
-/// falling back to `--bundled`). Returns the parsed `{models: [...]}`.
+/// Capture the native catalog from Codex Desktop's `models_cache.json` when
+/// available, falling back to the Codex CLI (`codex debug models`, then
+/// `--bundled`). Returns the parsed `{models: [...]}`.
 /// `exclude_slugs` lists additional slugs to drop (besides the built-in
 /// `provider/model` filter): in native slug mode our republished bare slugs
 /// echo back through `debug models` and must not pollute the next capture.
 pub fn capture_native_catalog(
     exclude_slugs: &std::collections::HashSet<String>,
 ) -> anyhow::Result<Value> {
+    if let Some(cached) = read_models_cache(exclude_slugs) {
+        persist_native_catalog(&cached)?;
+        return Ok(cached);
+    }
+
     let bin = codex_bin().ok_or_else(|| {
         anyhow::anyhow!("Codex CLI not found on PATH (set CODEX_BIN to its location)")
     })?;
@@ -48,6 +58,40 @@ pub fn capture_native_catalog(
     };
     let raw = run("").or_else(|_| run("--bundled"))?;
     let parsed: Value = serde_json::from_str(&raw)?;
+    let catalog = native_catalog_from_value(parsed, exclude_slugs)?;
+    persist_native_catalog(&catalog)?;
+    Ok(catalog)
+}
+
+fn read_models_cache(exclude_slugs: &std::collections::HashSet<String>) -> Option<Value> {
+    let raw = std::fs::read_to_string(codex_home().join("models_cache.json")).ok()?;
+    let parsed: Value = serde_json::from_str(&raw).ok()?;
+    let models = filtered_native_models(&parsed, exclude_slugs);
+    if models.is_empty() {
+        return None;
+    }
+    let mut catalog = json!({ "models": models });
+    ensure_native_catalog_backfills(&mut catalog);
+    Some(catalog)
+}
+
+fn native_catalog_from_value(
+    parsed: Value,
+    exclude_slugs: &std::collections::HashSet<String>,
+) -> anyhow::Result<Value> {
+    let models = filtered_native_models(&parsed, exclude_slugs);
+    if models.is_empty() {
+        anyhow::bail!("Codex returned an empty or invalid model catalog");
+    }
+    let mut catalog = json!({ "models": models });
+    ensure_native_catalog_backfills(&mut catalog);
+    Ok(catalog)
+}
+
+fn filtered_native_models(
+    parsed: &Value,
+    exclude_slugs: &std::collections::HashSet<String>,
+) -> Vec<Value> {
     let models: Vec<Value> = parsed
         .get("models")
         .and_then(Value::as_array)
@@ -67,17 +111,138 @@ pub fn capture_native_catalog(
                 .unwrap_or(true)
         })
         .collect();
-    if models.is_empty() {
-        anyhow::bail!("Codex returned an empty or invalid model catalog");
-    }
-    let mut catalog = json!({ "models": models });
-    ensure_native_catalog_backfills(&mut catalog);
+    models
+}
+
+fn persist_native_catalog(catalog: &Value) -> anyhow::Result<()> {
     std::fs::create_dir_all(loom_dir())?;
     std::fs::write(
         native_catalog_path(),
         serde_json::to_string_pretty(&catalog)?,
     )?;
-    Ok(catalog)
+    Ok(())
+}
+
+const CONFIG_LOAD_VALIDATION_TTL: Duration = Duration::from_secs(30);
+const CONFIG_LOAD_DOCTOR_TIMEOUT: Duration = Duration::from_secs(10);
+static CONFIG_LOAD_VALIDATION: Mutex<Option<(Instant, bool, Option<String>)>> = Mutex::new(None);
+
+#[cfg(test)]
+pub(crate) fn reset_validate_merged_catalog_cache() {
+    *CONFIG_LOAD_VALIDATION
+        .lock()
+        .unwrap_or_else(|p| p.into_inner()) = None;
+}
+
+/// Run `codex doctor` and report whether the merged catalog is loadable.
+///
+/// The desktop app can accept a config file while still freezing on
+/// `config_load`, so file presence alone is not a usable health signal.
+/// Cache the result for 30s because status runs on every screen open.
+pub fn validate_merged_catalog() -> (bool, Option<String>) {
+    let now = Instant::now();
+    if let Some((cached_at, ok, error)) = CONFIG_LOAD_VALIDATION
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+        .as_ref()
+    {
+        if now.duration_since(*cached_at) < CONFIG_LOAD_VALIDATION_TTL {
+            return (*ok, error.clone());
+        }
+    }
+
+    let result = run_validate_merged_catalog();
+    *CONFIG_LOAD_VALIDATION
+        .lock()
+        .unwrap_or_else(|p| p.into_inner()) = Some((Instant::now(), result.0, result.1.clone()));
+    result
+}
+
+fn run_validate_merged_catalog() -> (bool, Option<String>) {
+    let Some(bin) = codex_bin() else {
+        return (false, Some("codex CLI not found".to_string()));
+    };
+    match run_codex_doctor(&bin) {
+        Ok(Some(output))
+            if output.status.success() && !output.stdout.to_ascii_lowercase().contains("error") =>
+        {
+            (true, None)
+        }
+        Ok(Some(output)) => {
+            let error = output.stderr.trim().to_string();
+            (
+                false,
+                Some(if error.is_empty() {
+                    "codex doctor reported an error".to_string()
+                } else {
+                    error
+                }),
+            )
+        }
+        Ok(None) => (false, Some("codex doctor timed out".to_string())),
+        Err(e) => (false, Some(e.to_string())),
+    }
+}
+
+struct DoctorOutput {
+    status: std::process::ExitStatus,
+    stdout: String,
+    stderr: String,
+}
+
+fn run_codex_doctor(bin: &str) -> std::io::Result<Option<DoctorOutput>> {
+    let mut command = Command::new(bin);
+    crate::cli_locator::hide_console_window(&mut command);
+    crate::cli_locator::scrub_child_env_std(&mut command);
+    let mut child = command
+        .arg("doctor")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| std::io::Error::other("codex stdout unavailable"))?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| std::io::Error::other("codex stderr unavailable"))?;
+
+    let stdout_thread = std::thread::spawn(move || {
+        let mut output = String::new();
+        stdout.read_to_string(&mut output)?;
+        Ok::<String, std::io::Error>(output)
+    });
+    let stderr_thread = std::thread::spawn(move || {
+        let mut output = String::new();
+        stderr.read_to_string(&mut output)?;
+        Ok::<String, std::io::Error>(output)
+    });
+
+    let deadline = Instant::now() + CONFIG_LOAD_DOCTOR_TIMEOUT;
+    loop {
+        match child.try_wait()? {
+            Some(status) => {
+                let stdout = stdout_thread
+                    .join()
+                    .map_err(|_| std::io::Error::other("codex stdout reader failed"))??;
+                let stderr = stderr_thread
+                    .join()
+                    .map_err(|_| std::io::Error::other("codex stderr reader failed"))??;
+                return Ok(Some(DoctorOutput {
+                    status,
+                    stdout,
+                    stderr,
+                }));
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Ok(None);
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
 }
 
 pub(super) fn load_native_catalog() -> Value {

--- a/src-tauri/src/codex/catalog/tests.rs
+++ b/src-tauri/src/codex/catalog/tests.rs
@@ -399,3 +399,92 @@ fn native_slug_mode_bare_slug_collision_first_provider_wins() {
     assert_eq!(models[0]["slug"], "deepseek-chat");
     assert_eq!(models[0]["display_name"], "Other Chat");
 }
+
+#[cfg(unix)]
+fn fake_codex(dir: &std::path::Path, body: &str) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let bin = dir.join("codex");
+    std::fs::write(&bin, body).unwrap();
+    let mut permissions = std::fs::metadata(&bin).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&bin, permissions).unwrap();
+    bin
+}
+
+#[test]
+fn capture_native_catalog_prefers_models_cache_json() {
+    let _guard = super::super::codex_home_guard();
+    let dir = tempfile::tempdir().unwrap();
+    std::env::set_var("CODEX_HOME", dir.path());
+    std::env::set_var("CODEX_BIN", "loom-router-test-no-such-codex");
+    super::super::reset_codex_bin_cache();
+
+    let cache = json!({"models": [
+        {
+            "slug": "gpt-5.6-terra",
+            "shell_type": "native",
+            "truncation_policy": "auto",
+            "model_messages": [],
+            "comp_hash": "abc",
+            "node_repl_auto_review_required": false,
+            "node_repl_disabled": false,
+            "include_apps_usage_instructions": false,
+            "include_plugin_usage_instructions": false,
+            "include_skills_usage_instructions": false,
+            "apply_patch_tool_type": "builtin",
+            "tool_mode": "normal",
+            "web_search_tool_type": "builtin"
+        }
+    ]});
+    std::fs::write(dir.path().join("models_cache.json"), cache.to_string()).unwrap();
+
+    let catalog = capture_native_catalog(&std::collections::HashSet::new()).unwrap();
+    assert_eq!(catalog["models"][0]["slug"], "gpt-5.6-terra");
+    assert_eq!(catalog["models"][0]["shell_type"], "native");
+    let persisted =
+        std::fs::read_to_string(dir.path().join("loom-router/native-models.json")).unwrap();
+    assert!(persisted.contains("shell_type"));
+
+    std::env::remove_var("CODEX_HOME");
+    std::env::remove_var("CODEX_BIN");
+    super::super::reset_codex_bin_cache();
+}
+
+#[cfg(unix)]
+#[test]
+fn validate_merged_catalog_accepts_clean_doctor_output() {
+    let _guard = super::super::codex_home_guard();
+    let dir = tempfile::tempdir().unwrap();
+    let bin = fake_codex(dir.path(), "#!/bin/sh\necho OK\nexit 0\n");
+    std::env::set_var("CODEX_BIN", bin);
+    super::super::reset_codex_bin_cache();
+    super::reset_validate_merged_catalog_cache();
+
+    let (ok, error) = validate_merged_catalog();
+    assert!(ok);
+    assert!(error.is_none());
+
+    std::env::remove_var("CODEX_BIN");
+    super::super::reset_codex_bin_cache();
+    super::reset_validate_merged_catalog_cache();
+}
+
+#[cfg(unix)]
+#[test]
+fn validate_merged_catalog_rejects_failing_doctor() {
+    let _guard = super::super::codex_home_guard();
+    let dir = tempfile::tempdir().unwrap();
+    let bin = fake_codex(dir.path(), "#!/bin/sh\necho boom >&2\nexit 1\n");
+    std::env::set_var("CODEX_BIN", bin);
+    super::super::reset_codex_bin_cache();
+    super::reset_validate_merged_catalog_cache();
+
+    let (ok, error) = validate_merged_catalog();
+    assert!(!ok);
+    assert_eq!(error.as_deref(), Some("boom"));
+
+    std::env::remove_var("CODEX_BIN");
+    super::super::reset_codex_bin_cache();
+    super::reset_validate_merged_catalog_cache();
+}

--- a/src-tauri/src/codex/tests.rs
+++ b/src-tauri/src/codex/tests.rs
@@ -13,9 +13,17 @@ fn status_flags_orphaned_managed_block() {
         "# BEGIN loom-router-managed\nmodel_provider = \"loomrouter\"\n",
     )
     .unwrap();
+    super::reset_codex_bin_cache();
+    catalog::reset_validate_merged_catalog_cache();
+    std::env::set_var("CODEX_BIN", "loom-router-test-no-such-codex");
     let status = status(&AppConfig::default());
     assert!(status.managed_block_present);
     assert!(status.managed_block_orphaned);
+    assert!(!status.codex_config_loads);
+    assert!(status.codex_config_error.is_some());
+    std::env::remove_var("CODEX_BIN");
+    super::reset_codex_bin_cache();
+    catalog::reset_validate_merged_catalog_cache();
     std::env::remove_var("CODEX_HOME");
     let _ = std::fs::remove_dir_all(&tmp);
 }
@@ -31,9 +39,17 @@ fn status_does_not_flag_complete_managed_block() {
         "# BEGIN loom-router-managed\nmodel_provider = \"loomrouter\"\n# END loom-router-managed\n",
     )
     .unwrap();
+    super::reset_codex_bin_cache();
+    catalog::reset_validate_merged_catalog_cache();
+    std::env::set_var("CODEX_BIN", "loom-router-test-no-such-codex");
     let status = status(&AppConfig::default());
     assert!(status.managed_block_present);
     assert!(!status.managed_block_orphaned);
+    assert!(!status.codex_config_loads);
+    assert!(status.codex_config_error.is_some());
+    std::env::remove_var("CODEX_BIN");
+    super::reset_codex_bin_cache();
+    catalog::reset_validate_merged_catalog_cache();
     std::env::remove_var("CODEX_HOME");
     let _ = std::fs::remove_dir_all(&tmp);
 }

--- a/src-tauri/src/codex/tests.rs
+++ b/src-tauri/src/codex/tests.rs
@@ -19,8 +19,10 @@ fn status_flags_orphaned_managed_block() {
     let status = status(&AppConfig::default());
     assert!(status.managed_block_present);
     assert!(status.managed_block_orphaned);
+    // No merged catalog and integration off: the doctor probe is skipped
+    // rather than shelling out on every screen open.
     assert!(!status.codex_config_loads);
-    assert!(status.codex_config_error.is_some());
+    assert!(status.codex_config_error.is_none());
     std::env::remove_var("CODEX_BIN");
     super::reset_codex_bin_cache();
     catalog::reset_validate_merged_catalog_cache();
@@ -45,8 +47,10 @@ fn status_does_not_flag_complete_managed_block() {
     let status = status(&AppConfig::default());
     assert!(status.managed_block_present);
     assert!(!status.managed_block_orphaned);
+    // No merged catalog and integration off: the doctor probe is skipped
+    // rather than shelling out on every screen open.
     assert!(!status.codex_config_loads);
-    assert!(status.codex_config_error.is_some());
+    assert!(status.codex_config_error.is_none());
     std::env::remove_var("CODEX_BIN");
     super::reset_codex_bin_cache();
     catalog::reset_validate_merged_catalog_cache();

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -629,6 +629,8 @@ mod tests {
             merged_catalog_present: managed_block_present,
             merged_model_count: usize::from(managed_block_present),
             codex_cli_available: true,
+            codex_config_loads: true,
+            codex_config_error: None,
             integration_enabled: true,
             session: codex::CodexSessionStatus {
                 path: String::new(),

--- a/src-tauri/src/state/lifecycle.rs
+++ b/src-tauri/src/state/lifecycle.rs
@@ -563,6 +563,10 @@ impl AppState {
         // The apply refreshed the native catalog, so discard the old picker
         // result before reporting integration as enabled.
         self.invalidate_native_slugs_cache().await;
+        // The catalog on disk just changed; the cached `codex doctor` verdict
+        // describes the pre-apply state and would keep the panel red for the
+        // rest of its TTL.
+        codex::invalidate_merged_catalog_validation();
         self.config.write().await.codex_integration = true;
         self.persist().await
     }
@@ -570,6 +574,7 @@ impl AppState {
     pub async fn codex_remove(&self) -> anyhow::Result<()> {
         let cfg = self.config.read().await.clone();
         codex::remove(Some(&cfg))?;
+        codex::invalidate_merged_catalog_validation();
         {
             let mut cfg = self.config.write().await;
             cfg.codex_integration = false;

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -22,6 +22,8 @@ const statusPayload = (managed_block_orphaned: boolean): CodexStatus => ({
   merged_catalog_present: false,
   merged_model_count: 0,
   codex_cli_available: true,
+  codex_config_loads: true,
+  codex_config_error: null,
   integration_enabled: false,
   session: {
     path: '~/.codex/auth.json',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -224,6 +224,7 @@ const en = {
     sessionUsable: 'Local Codex session is usable',
     nativeCatalog: 'Native catalog captured',
     codexConfigLoads: 'Codex loads the config',
+    codexConfigBroken: 'Codex cannot load the config',
     codexConfigError: 'Codex rejects the catalog: {{error}}',
     restartHint: 'Fully quit and reopen Codex after applying - Codex only loads the catalog at startup.',
     orphanedHint: 'Codex config was rewritten externally and lost its managed block markers. Apply or remove the integration to repair it - your own settings are preserved.',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -223,6 +223,8 @@ const en = {
     sessionExpired: 'Local Codex session is expired',
     sessionUsable: 'Local Codex session is usable',
     nativeCatalog: 'Native catalog captured',
+    codexConfigLoads: 'Codex loads the config',
+    codexConfigError: 'Codex rejects the catalog: {{error}}',
     restartHint: 'Fully quit and reopen Codex after applying - Codex only loads the catalog at startup.',
     orphanedHint: 'Codex config was rewritten externally and lost its managed block markers. Apply or remove the integration to repair it - your own settings are preserved.',
     repairTitle: 'Repair Codex integration?',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -221,6 +221,8 @@ const es: DeepPartial<Strings> = {
     sessionExpired: 'La sesión local de Codex expiró',
     sessionUsable: 'La sesión local de Codex es utilizable',
     nativeCatalog: 'Catálogo nativo capturado',
+    codexConfigLoads: 'Codex carga la configuración',
+    codexConfigError: 'Codex rechazó el catálogo: {{error}}',
     restartHint: 'Cierra por completo y vuelve a abrir Codex después de aplicar: Codex solo carga el catálogo al iniciar.',
     orphanedHint: 'La configuración de Codex se reescribió externamente y perdió los marcadores del bloque gestionado. Aplica o quita la integración para repararlo: tus ajustes se conservan.',
     repairTitle: '¿Reparar la integración con Codex?',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -222,6 +222,7 @@ const es: DeepPartial<Strings> = {
     sessionUsable: 'La sesión local de Codex es utilizable',
     nativeCatalog: 'Catálogo nativo capturado',
     codexConfigLoads: 'Codex carga la configuración',
+    codexConfigBroken: 'Codex no puede cargar la configuración',
     codexConfigError: 'Codex rechazó el catálogo: {{error}}',
     restartHint: 'Cierra por completo y vuelve a abrir Codex después de aplicar: Codex solo carga el catálogo al iniciar.',
     orphanedHint: 'La configuración de Codex se reescribió externamente y perdió los marcadores del bloque gestionado. Aplica o quita la integración para repararlo: tus ajustes se conservan.',

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -221,6 +221,7 @@ const pt: DeepPartial<Strings> = {
     sessionUsable: 'A sessão local do Codex está utilizável',
     nativeCatalog: 'Catálogo nativo capturado',
     codexConfigLoads: 'Codex carrega a configuração',
+    codexConfigBroken: 'Codex não consegue carregar a configuração',
     codexConfigError: 'Codex recusou o catálogo: {{error}}',
     restartHint: 'Feche completamente e reabra o Codex após aplicar - o Codex só carrega o catálogo na inicialização.',
     orphanedHint: 'O config do Codex foi reescrito externamente e perdeu os marcadores do bloco gerenciado. Aplique ou remova a integração para reparar - suas configurações são preservadas.',

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -220,6 +220,8 @@ const pt: DeepPartial<Strings> = {
     sessionExpired: 'A sessão local do Codex expirou',
     sessionUsable: 'A sessão local do Codex está utilizável',
     nativeCatalog: 'Catálogo nativo capturado',
+    codexConfigLoads: 'Codex carrega a configuração',
+    codexConfigError: 'Codex recusou o catálogo: {{error}}',
     restartHint: 'Feche completamente e reabra o Codex após aplicar - o Codex só carrega o catálogo na inicialização.',
     orphanedHint: 'O config do Codex foi reescrito externamente e perdeu os marcadores do bloco gerenciado. Aplique ou remova a integração para reparar - suas configurações são preservadas.',
     repairTitle: 'Reparar integração do Codex?',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -219,6 +219,8 @@ const zh: DeepPartial<Strings> = {
     sessionExpired: '本地 Codex 会话已过期',
     sessionUsable: '本地 Codex 会话可用',
     nativeCatalog: '已捕获原生目录',
+    codexConfigLoads: 'Codex 可加载配置',
+    codexConfigError: 'Codex 拒绝了目录：{{error}}',
     restartHint: '应用后请完全退出并重新打开 Codex - Codex 只在启动时加载目录。',
     orphanedHint: 'Codex 配置被外部重写，丢失了受管块的标记。应用或移除集成即可修复 - 你自己的设置会被保留。',
     repairTitle: '修复 Codex 集成？',

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -220,6 +220,7 @@ const zh: DeepPartial<Strings> = {
     sessionUsable: '本地 Codex 会话可用',
     nativeCatalog: '已捕获原生目录',
     codexConfigLoads: 'Codex 可加载配置',
+    codexConfigBroken: 'Codex 无法加载配置',
     codexConfigError: 'Codex 拒绝了目录：{{error}}',
     restartHint: '应用后请完全退出并重新打开 Codex - Codex 只在启动时加载目录。',
     orphanedHint: 'Codex 配置被外部重写，丢失了受管块的标记。应用或移除集成即可修复 - 你自己的设置会被保留。',

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -477,6 +477,8 @@ function mock<T>(cmd: string, args?: Record<string, unknown>): Promise<T> {
         merged_catalog_present: mockState.codexApplied,
         merged_model_count: mockState.codexApplied ? 1 : 0,
         codex_cli_available: true,
+        codex_config_loads: mockState.codexApplied,
+        codex_config_error: null,
         integration_enabled: mockState.codexApplied,
         session: {
           path: '~/.codex/auth.json',

--- a/src/pages/Codex.test.tsx
+++ b/src/pages/Codex.test.tsx
@@ -48,6 +48,8 @@ vi.mock('@/lib/api', () => ({
         merged_catalog_present: true,
         merged_model_count: 3,
         codex_cli_available: true,
+        codex_config_loads: true,
+        codex_config_error: null,
         integration_enabled: true,
         session: {
           path: '~/.codex/auth.json',

--- a/src/pages/Codex.tsx
+++ b/src/pages/Codex.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { CheckCircle2, XCircle } from 'lucide-react'
+import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react'
 import { api } from '@/lib/api'
 import { useBackendState } from '@/lib/events'
 import { useStrings } from '@/i18n'
@@ -145,6 +145,21 @@ export default function CodexPage() {
             label={s.codex.mergedCatalog}
             detail={s.codex.modelsInPicker.replace('{{count}}', String(status?.merged_model_count ?? 0))}
           />
+          <div className="flex items-start gap-2 text-sm">
+            {status?.codex_config_loads ? (
+              <CheckCircle2 className="h-4 w-4 mt-0.5 text-green-500" />
+            ) : (
+              <AlertTriangle className="h-4 w-4 mt-0.5 text-red-500" />
+            )}
+            <div>
+              <div>{s.codex.codexConfigLoads}</div>
+              {status?.codex_config_error && (
+                <div className="text-xs text-red-600 dark:text-red-500 font-mono break-all">
+                  {s.codex.codexConfigError.replace('{{error}}', status.codex_config_error)}
+                </div>
+              )}
+            </div>
+          </div>
           <div className="flex gap-2">
             {active ? (
               <Button variant="outline" onClick={remove} disabled={busy}>

--- a/src/pages/Codex.tsx
+++ b/src/pages/Codex.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { AlertTriangle, CheckCircle2, XCircle } from 'lucide-react'
+import { CheckCircle2, XCircle } from 'lucide-react'
 import { api } from '@/lib/api'
 import { useBackendState } from '@/lib/events'
 import { useStrings } from '@/i18n'
@@ -145,21 +145,21 @@ export default function CodexPage() {
             label={s.codex.mergedCatalog}
             detail={s.codex.modelsInPicker.replace('{{count}}', String(status?.merged_model_count ?? 0))}
           />
-          <div className="flex items-start gap-2 text-sm">
-            {status?.codex_config_loads ? (
-              <CheckCircle2 className="h-4 w-4 mt-0.5 text-green-500" />
-            ) : (
-              <AlertTriangle className="h-4 w-4 mt-0.5 text-red-500" />
-            )}
-            <div>
-              <div>{s.codex.codexConfigLoads}</div>
-              {status?.codex_config_error && (
-                <div className="text-xs text-red-600 dark:text-red-500 font-mono break-all">
-                  {s.codex.codexConfigError.replace('{{error}}', status.codex_config_error)}
-                </div>
-              )}
-            </div>
-          </div>
+          {/* Only meaningful once a catalog has been published: before that
+              the backend skips the probe and there is nothing to report. */}
+          {active && (
+            <StatusRow
+              ok={status?.codex_config_loads ?? false}
+              label={
+                status?.codex_config_loads ? s.codex.codexConfigLoads : s.codex.codexConfigBroken
+              }
+              detail={
+                status?.codex_config_error
+                  ? s.codex.codexConfigError.replace('{{error}}', status.codex_config_error)
+                  : undefined
+              }
+            />
+          )}
           <div className="flex gap-2">
             {active ? (
               <Button variant="outline" onClick={remove} disabled={busy}>

--- a/src/pages/Onboarding.test.tsx
+++ b/src/pages/Onboarding.test.tsx
@@ -159,6 +159,8 @@ vi.mock('@/lib/api', () => ({
         merged_catalog_present: codexManaged,
         merged_model_count: codexManaged ? 1 : 0,
         codex_cli_available: codexCliAvailable,
+        codex_config_loads: codexManaged,
+        codex_config_error: null,
         integration_enabled: codexManaged,
         session: {
           path: '~/.codex/auth.json',

--- a/src/pages/Server.test.tsx
+++ b/src/pages/Server.test.tsx
@@ -93,6 +93,8 @@ vi.mock('@/lib/api', () => ({
         merged_catalog_present: true,
         merged_model_count: 2,
         codex_cli_available: true,
+        codex_config_loads: true,
+        codex_config_error: null,
         integration_enabled: true,
         session: {
           path: '~/.codex/auth.json',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -190,6 +190,8 @@ export interface CodexStatus {
   merged_catalog_present: boolean
   merged_model_count: number
   codex_cli_available: boolean
+  codex_config_loads: boolean
+  codex_config_error: string | null
   integration_enabled: boolean
   session: CodexSessionStatus
 }


### PR DESCRIPTION
Closes #78.

## Root cause

The Codex integration built `merged-models.json` from `codex debug models`, which returns a stripped subset of Codex's full model schema. The desktop app requires fields like `shell_type`, `truncation_policy`, `model_messages`, `comp_hash`, `node_repl_*`, `include_*_usage_instructions`, `apply_patch_tool_type`, `tool_mode`, `web_search_tool_type` — all present in Codex's own `~/.codex/models_cache.json` but absent from `codex debug models`. Without them, the desktop app freezes on `config_load` and the LoomRouter panel reports "Integration active" because it only checks that the file exists.

## Fix

- `capture_native_catalog` now prefers `~/.codex/models_cache.json` (Codex's own runtime cache, which carries the full schema) and falls back to `codex debug models` → `--bundled` when missing or unparseable. Existing slug filter and backfill unchanged.
- New `validate_merged_catalog()` runs `codex doctor` (10s timeout, child killed on timeout) and caches the result for 30s via a stdlib `Mutex<Option<(Instant, bool, Option<String>)>>`. Exposed through `CodexStatus.codex_config_loads` and `.codex_config_error`.
- Codex panel renders a green badge ("Codex loads the config") or a red `AlertTriangle` with the doctor's stderr.
- i18n strings added in en/pt/es/zh using the existing `{{var}}` template pattern.

## Tests

- `capture_native_catalog_prefers_models_cache_json`: writes a `models_cache.json` carrying the missing fields, points `CODEX_HOME` and `CODEX_BIN` at a non-existent path, and asserts `shell_type` (and the others) survive into `native-models.json`.
- `validate_merged_catalog_accepts_clean_doctor_output` / `_rejects_failing_doctor`: stub `CODEX_BIN` with a `/bin/sh` script that exits 0 / 1.
- `status_flags_orphaned_managed_block` / `status_does_not_flag_complete_managed_block`: now stub `CODEX_BIN` so `status()` doesn't shell out to the real CLI.

## Caveats

- New tests are `#[cfg(unix)]` (the fake-binary helper); CI (`ubuntu-latest`) exercises them. The implementation itself uses the existing cross-platform subprocess helpers (`hide_console_window`, `scrub_child_env_std`) and `child.kill()`, but Windows validation is left to the maintainer.
- The stdout-"error" check is a literal substring heuristic on top of the exit code, per the original plan; trivially tunable later if a future `codex doctor` emits something like `No errors found`.