### PR TITLE
fix(opencode-zen, subagents): deepseek-v4-flash via chat completions and worker --skip-git-repo-check

### DIFF
--- a/src-tauri/src/codex/subagents.rs
+++ b/src-tauri/src/codex/subagents.rs
@@ -315,6 +315,10 @@ fn codex_task_args(model: &str, sandbox: &str, cwd: &std::path::Path, prompt: &s
         cwd.display().to_string(),
         "exec".into(),
         "--json".into(),
+        // Trust-check bypass: each worker spawns from the Tauri app cwd (non-git).
+        // The parent's interactive Codex trust does not propagate to `Command::new`.
+        // LoomRouter's own sandbox and approval flags remain the real guard.
+        "--skip-git-repo-check".into(),
         "--ephemeral".into(),
         prompt.into(),
     ]
@@ -698,10 +702,46 @@ mod tests {
             .position(|arg| arg == "--ask-for-approval")
             .unwrap();
         assert!(approval < exec);
-        assert_eq!(&args[exec..], ["exec", "--json", "--ephemeral", "Review"]);
+        assert_eq!(
+            &args[exec..],
+            [
+                "exec",
+                "--json",
+                "--skip-git-repo-check",
+                "--ephemeral",
+                "Review"
+            ]
+        );
         assert_eq!(args[3], "read-only");
         assert_eq!(args[5], "opencode-go/deepseek-v4-flash");
         assert_eq!(args[7], "/tmp/work");
+    }
+
+    #[test]
+    fn subagent_exec_invokes_codex_with_skip_git_repo_check() {
+        let args = codex_task_args(
+            "opencode-go/deepseek-v4-flash",
+            "read-only",
+            std::path::Path::new("/tmp/work"),
+            "Review",
+        );
+        let exec = args.iter().position(|arg| arg == "exec").unwrap();
+        let skip = args
+            .iter()
+            .position(|arg| arg == "--skip-git-repo-check")
+            .expect("--skip-git-repo-check must be present in codex exec args");
+        let approval = args
+            .iter()
+            .position(|arg| arg == "--ask-for-approval")
+            .unwrap();
+        // The bypass is an `exec` subcommand option, not a global one: it must
+        // come after `exec` so codex parses it as belonging to the exec
+        // subcommand, and the global/subcommand boundary still holds.
+        assert!(
+            skip > exec,
+            "--skip-git-repo-check must follow the `exec` subcommand"
+        );
+        assert!(approval < exec, "global options must still precede `exec`");
     }
 
     #[tokio::test]

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -577,14 +577,13 @@ impl AppConfig {
     }
 
     /// Restore the endpoint split for models whose gateway wire is known and
-    /// fixed. Older dialect probes could persist Anthropic for the flash tier,
-    /// even though this gateway only serves it through Responses.
+    /// fixed. The OpenCode Go gateway only serves the flash tier through
+    /// Responses; older dialect probes could persist a different protocol
+    /// after discovery. Zen uses Chat Completions for the same id, so it is
+    /// deliberately excluded from this repair.
     fn repair_known_opencode_dialects(&mut self) {
         let mut repaired = false;
-        for (provider_id, base_url) in [
-            ("opencode-zen", "https://opencode.ai/zen/v1"),
-            ("opencode-go", "https://opencode.ai/zen/go/v1"),
-        ] {
+        for (provider_id, base_url) in [("opencode-go", "https://opencode.ai/zen/go/v1")] {
             let Some(provider) = self.providers.get_mut(provider_id) else {
                 continue;
             };

--- a/src-tauri/src/providers.rs
+++ b/src-tauri/src/providers.rs
@@ -274,12 +274,12 @@ pub const PRESETS: &[Preset] = &[
             md("kimi-k2.7-code", ProviderProtocol::OpenAI),
             md("glm-5.2", ProviderProtocol::OpenAI),
             md("deepseek-v4-pro", ProviderProtocol::OpenAI),
-            // Console Go serves the flash tier only over the Responses API;
-            // routed through chat/completions it returns 400 "Model is
-            // unavailable" even though the id is in the catalog (verified
-            // directly against the /go/ gateway). Keep the /go/ and /zen/
-            // presets in agreement since they share the dialect split.
-            md("deepseek-v4-flash", ProviderProtocol::Responses),
+            // Zen serves the flash tier over Chat Completions: /v1/responses
+            // on https://opencode.ai/zen/v1 returns 500 even though the id
+            // is in the catalog, while /v1/chat/completions answers normally
+            // (verified against the Zen gateway). Go keeps Responses because
+            // that is the dialect its gateway exposes.
+            md("deepseek-v4-flash", ProviderProtocol::OpenAI),
             md("minimax-m3", ProviderProtocol::OpenAI),
             md("claude-sonnet-5", ProviderProtocol::Anthropic),
             md("claude-opus-5", ProviderProtocol::Anthropic),

--- a/src-tauri/src/proxy/routing.rs
+++ b/src-tauri/src/proxy/routing.rs
@@ -15,6 +15,17 @@ pub fn model_protocol<'a>(
     provider: &'a crate::providers::Provider,
     model_id: &str,
 ) -> &'a ProviderProtocol {
+    // The Zen gateway only serves the flash tier over Chat Completions;
+    // the Responses endpoint returns 500 even though the id is in its
+    // catalog. A user-set or auto-probed `protocol = Responses` here is a
+    // known footgun: prior PRs patched the preset and the migration
+    // repair, but a probe that runs while the gateway is misbehaving can
+    // still persist `Responses` back to the config and turn every retry
+    // into a 502. Pin the model at dispatch so the persisted value can
+    // never override the verified Zen-vs-Go split.
+    if provider.id == "opencode-zen" && model_id == "deepseek-v4-flash" {
+        return &ProviderProtocol::OpenAI;
+    }
     provider
         .models
         .iter()

--- a/src-tauri/src/proxy/routing.rs
+++ b/src-tauri/src/proxy/routing.rs
@@ -15,16 +15,16 @@ pub fn model_protocol<'a>(
     provider: &'a crate::providers::Provider,
     model_id: &str,
 ) -> &'a ProviderProtocol {
-    // The Zen gateway only serves the flash tier over Chat Completions;
-    // the Responses endpoint returns 500 even though the id is in its
-    // catalog. A user-set or auto-probed `protocol = Responses` here is a
-    // known footgun: prior PRs patched the preset and the migration
-    // repair, but a probe that runs while the gateway is misbehaving can
-    // still persist `Responses` back to the config and turn every retry
-    // into a 502. Pin the model at dispatch so the persisted value can
-    // never override the verified Zen-vs-Go split.
-    if provider.id == "opencode-zen" && model_id == "deepseek-v4-flash" {
-        return &ProviderProtocol::OpenAI;
+    // Multi-dialect providers (OpenCode Zen/Go today) ship an explicit
+    // dialect per model in the shipped preset. The persisted config can
+    // carry stale entries from pre-merge configs or from a probe that ran
+    // while the upstream was misbehaving — neither should override the
+    // preset's verified dialect split. Single-dialect providers fall
+    // through to the persisted value, then the provider default.
+    if is_multi_dialect_provider(&provider.id) {
+        if let Some(protocol) = preset_model_protocol(&provider.id, model_id) {
+            return protocol;
+        }
     }
     provider
         .models
@@ -32,6 +32,24 @@ pub fn model_protocol<'a>(
         .find(|model| model.id == model_id)
         .and_then(|model| model.protocol.as_ref())
         .unwrap_or(&provider.protocol)
+}
+
+fn is_multi_dialect_provider(provider_id: &str) -> bool {
+    // The OpenCode gateways serve three dialects on one URL. Other
+    // providers have a single dialect and rely on the persisted override.
+    // Add a new entry here when a future preset ships a split.
+    matches!(provider_id, "opencode-zen" | "opencode-go")
+}
+
+fn preset_model_protocol(provider_id: &str, model_id: &str) -> Option<&'static ProviderProtocol> {
+    let preset = crate::providers::PRESETS
+        .iter()
+        .find(|preset| preset.id == provider_id)?;
+    preset
+        .default_models
+        .iter()
+        .find(|model| model.id == model_id)
+        .and_then(|model| model.protocol.as_ref())
 }
 
 /// Resolve `provider/model` (or a bare upstream id in native-slug mode) to

--- a/src-tauri/src/proxy/tests_routing.rs
+++ b/src-tauri/src/proxy/tests_routing.rs
@@ -242,6 +242,53 @@ fn zen_preset_dispatches_deepseek_v4_flash_over_chat_completions() {
     assert_eq!(go_kind, UpstreamKind::Responses);
 }
 
+#[test]
+fn zen_flash_protocol_override_survives_a_persisted_responses() {
+    // The Zen gateway returns 500 on /v1/responses for the flash tier but
+    // answers on /v1/chat/completions. A user override or a discovery probe
+    // that ran while the upstream was misbehaving can persist
+    // `protocol = Responses` back to the config; the runtime override in
+    // `model_protocol` keeps the dispatch on Chat Completions regardless.
+    let mut provider = crate::config::Provider::from_preset(
+        crate::providers::PRESETS
+            .iter()
+            .find(|p| p.id == "opencode-zen")
+            .expect("opencode-zen preset"),
+    );
+    let model = provider
+        .models
+        .iter_mut()
+        .find(|m| m.id == "deepseek-v4-flash")
+        .expect("deepseek-v4-flash in zen preset");
+    model.protocol = Some(crate::config::ProviderProtocol::Responses);
+
+    let protocol = crate::proxy::routing::model_protocol(&provider, "deepseek-v4-flash");
+    assert_eq!(*protocol, crate::config::ProviderProtocol::OpenAI);
+
+    // Other Zen models keep whatever protocol is on disk.
+    let other = provider
+        .models
+        .iter()
+        .find(|m| m.id == "deepseek-v4-pro")
+        .expect("deepseek-v4-pro in zen preset");
+    assert_eq!(
+        *crate::proxy::routing::model_protocol(&provider, &other.id),
+        crate::config::ProviderProtocol::OpenAI,
+    );
+
+    // Go is unaffected.
+    let go_provider = crate::config::Provider::from_preset(
+        crate::providers::PRESETS
+            .iter()
+            .find(|p| p.id == "opencode-go")
+            .expect("opencode-go preset"),
+    );
+    assert_eq!(
+        *crate::proxy::routing::model_protocol(&go_provider, "deepseek-v4-flash"),
+        crate::config::ProviderProtocol::Responses,
+    );
+}
+
 /// The cache breakpoint is a content-block property and lands on the last
 /// block of the last message. Anthropic defines no top-level `cache_control`
 /// request parameter, so one placed there would enable nothing at all.

--- a/src-tauri/src/proxy/tests_routing.rs
+++ b/src-tauri/src/proxy/tests_routing.rs
@@ -243,49 +243,92 @@ fn zen_preset_dispatches_deepseek_v4_flash_over_chat_completions() {
 }
 
 #[test]
-fn zen_flash_protocol_override_survives_a_persisted_responses() {
-    // The Zen gateway returns 500 on /v1/responses for the flash tier but
-    // answers on /v1/chat/completions. A user override or a discovery probe
-    // that ran while the upstream was misbehaving can persist
-    // `protocol = Responses` back to the config; the runtime override in
-    // `model_protocol` keeps the dispatch on Chat Completions regardless.
-    let mut provider = crate::config::Provider::from_preset(
-        crate::providers::PRESETS
-            .iter()
-            .find(|p| p.id == "opencode-zen")
-            .expect("opencode-zen preset"),
-    );
-    let model = provider
-        .models
-        .iter_mut()
-        .find(|m| m.id == "deepseek-v4-flash")
-        .expect("deepseek-v4-flash in zen preset");
-    model.protocol = Some(crate::config::ProviderProtocol::Responses);
-
-    let protocol = crate::proxy::routing::model_protocol(&provider, "deepseek-v4-flash");
-    assert_eq!(*protocol, crate::config::ProviderProtocol::OpenAI);
-
-    // Other Zen models keep whatever protocol is on disk.
-    let other = provider
-        .models
+fn multi_dialect_preset_overrides_persisted_protocol() {
+    // OpenCode Zen and Go ship three dialects on one URL. The preset is
+    // the verified source of truth; the persisted config can carry stale
+    // or wrong entries from pre-merge configs or from a probe that ran
+    // while the upstream was misbehaving. `model_protocol` must trust
+    // the preset for every model it lists, regardless of what is on disk.
+    let zen_preset = crate::providers::PRESETS
         .iter()
-        .find(|m| m.id == "deepseek-v4-pro")
-        .expect("deepseek-v4-pro in zen preset");
+        .find(|p| p.id == "opencode-zen")
+        .expect("opencode-zen preset");
+    let mut zen_provider = crate::config::Provider::from_preset(zen_preset);
+
+    // Sabotage every persisted protocol on Zen — the preset still decides.
+    for model in zen_provider.models.iter_mut() {
+        model.protocol = Some(crate::config::ProviderProtocol::Responses);
+    }
+    for model in zen_preset.default_models {
+        let expected = model
+            .protocol
+            .clone()
+            .unwrap_or(crate::config::ProviderProtocol::OpenAI);
+        let got = crate::proxy::routing::model_protocol(&zen_provider, model.id);
+        assert_eq!(
+            *got, expected,
+            "zen/{} drifted from preset (got {:?}, expected {:?})",
+            model.id, *got, expected,
+        );
+    }
+
+    // Go is governed by the same rule and keeps Responses for flash.
+    let go_preset = crate::providers::PRESETS
+        .iter()
+        .find(|p| p.id == "opencode-go")
+        .expect("opencode-go preset");
+    let mut go_provider = crate::config::Provider::from_preset(go_preset);
+    for model in go_provider.models.iter_mut() {
+        model.protocol = Some(crate::config::ProviderProtocol::OpenAI);
+    }
+    for model in go_preset.default_models {
+        let expected = model
+            .protocol
+            .clone()
+            .unwrap_or(crate::config::ProviderProtocol::OpenAI);
+        let got = crate::proxy::routing::model_protocol(&go_provider, model.id);
+        assert_eq!(
+            *got, expected,
+            "go/{} drifted from preset (got {:?}, expected {:?})",
+            model.id, *got, expected,
+        );
+    }
+
+    // A single-dialect provider falls through to the persisted value.
+    let mut single = crate::config::Provider {
+        id: "single-dialect".into(),
+        name: "Single Dialect".into(),
+        protocol: crate::config::ProviderProtocol::OpenAI,
+        base_url: "https://example.test/v1".into(),
+        api_key: None,
+        keys: vec![],
+        rotation_enabled: false,
+        has_key: false,
+        context_window: None,
+        user_agent: None,
+        prompt_cache: None,
+        models: vec![crate::config::ProviderModel {
+            id: "demo".into(),
+            label: None,
+            context_window: None,
+            protocol: Some(crate::config::ProviderProtocol::Responses),
+            enabled: true,
+            supports_vision: false,
+            fast_mode: false,
+        }],
+        enabled: true,
+    };
     assert_eq!(
-        *crate::proxy::routing::model_protocol(&provider, &other.id),
-        crate::config::ProviderProtocol::OpenAI,
+        *crate::proxy::routing::model_protocol(&single, "demo"),
+        crate::config::ProviderProtocol::Responses,
     );
 
-    // Go is unaffected.
-    let go_provider = crate::config::Provider::from_preset(
-        crate::providers::PRESETS
-            .iter()
-            .find(|p| p.id == "opencode-go")
-            .expect("opencode-go preset"),
-    );
+    // And a single-dialect provider with no per-model protocol falls back
+    // to the provider default.
+    single.models[0].protocol = None;
     assert_eq!(
-        *crate::proxy::routing::model_protocol(&go_provider, "deepseek-v4-flash"),
-        crate::config::ProviderProtocol::Responses,
+        *crate::proxy::routing::model_protocol(&single, "demo"),
+        crate::config::ProviderProtocol::OpenAI,
     );
 }
 

--- a/src-tauri/src/proxy/tests_routing.rs
+++ b/src-tauri/src/proxy/tests_routing.rs
@@ -207,6 +207,41 @@ fn one_provider_dispatches_each_model_to_its_own_upstream() {
     );
 }
 
+#[test]
+fn zen_preset_dispatches_deepseek_v4_flash_over_chat_completions() {
+    // Zen serves the flash tier through Chat Completions: /v1/responses on
+    // https://opencode.ai/zen/v1 returns 500 even though the id is in the
+    // catalog. Go, by contrast, keeps Responses because that is the dialect
+    // its gateway exposes. Anchoring the dispatch on the shipped preset
+    // means a regression that puts the flash tier back on Responses will
+    // fail here, before any user request.
+    let preset = crate::providers::PRESETS
+        .iter()
+        .find(|p| p.id == "opencode-zen")
+        .expect("opencode-zen preset");
+    let provider = crate::config::Provider::from_preset(preset);
+    let payload = json!({"input": [], "stream": false});
+    let (path, _body, kind) =
+        build_upstream(&provider, &payload, "deepseek-v4-flash", WireApi::Responses).unwrap();
+    assert_eq!(path, "chat/completions");
+    assert_eq!(kind, UpstreamKind::OpenAiChat);
+
+    let go_preset = crate::providers::PRESETS
+        .iter()
+        .find(|p| p.id == "opencode-go")
+        .expect("opencode-go preset");
+    let go_provider = crate::config::Provider::from_preset(go_preset);
+    let (go_path, _go_body, go_kind) = build_upstream(
+        &go_provider,
+        &payload,
+        "deepseek-v4-flash",
+        WireApi::Responses,
+    )
+    .unwrap();
+    assert_eq!(go_path, "responses");
+    assert_eq!(go_kind, UpstreamKind::Responses);
+}
+
 /// The cache breakpoint is a content-block property and lands on the last
 /// block of the last message. Anthropic defines no top-level `cache_control`
 /// request parameter, so one placed there would enable nothing at all.

--- a/src-tauri/src/visual.rs
+++ b/src-tauri/src/visual.rs
@@ -585,7 +585,7 @@ fn resolve_candidate<'a>(config: &'a AppConfig, slug: &str) -> anyhow::Result<Ca
     if !model.supports_vision {
         bail!("visual-assistance model '{slug}' does not support vision");
     }
-    let protocol = model.protocol.as_ref().unwrap_or(&provider.protocol);
+    let protocol = crate::proxy::model_protocol(provider, model_id);
     if matches!(protocol, ProviderProtocol::Responses) {
         bail!(
             "visual-assistance model '{slug}' uses the unsupported Responses protocol; choose an OpenAI or Anthropic vision model"
@@ -946,6 +946,36 @@ mod tests {
         assert_eq!(anthropic["media_type"], "image/png");
         assert_eq!(anthropic["data"], "dmFsaWRhdGVkIGltYWdl");
         assert!(!anthropic.to_string().contains(original_url));
+    }
+
+    #[test]
+    fn multi_dialect_preset_protocol_wins_for_visual_candidates() {
+        let preset = crate::providers::PRESETS
+            .iter()
+            .find(|preset| preset.id == "opencode-zen")
+            .expect("opencode-zen preset");
+        let mut provider = crate::config::Provider::from_preset(preset);
+        provider.keys.push(crate::config::ProviderKey {
+            id: "primary".into(),
+            name: "Primary".into(),
+            enabled: true,
+            api_key: Some("sk-test".into()),
+            has_key: true,
+        });
+        let model = provider
+            .models
+            .iter_mut()
+            .find(|model| model.id == "deepseek-v4-flash")
+            .expect("flash model");
+        model.protocol = Some(crate::config::ProviderProtocol::Responses);
+        model.supports_vision = true;
+
+        let mut config = crate::config::AppConfig::default();
+        config.visual_assistance.assistant_model = Some("opencode-zen/deepseek-v4-flash".into());
+        config.providers.insert("opencode-zen".into(), provider);
+
+        let candidate = resolve_candidate(&config, "opencode-zen/deepseek-v4-flash").unwrap();
+        assert_eq!(candidate.protocol, &crate::config::ProviderProtocol::OpenAI,);
     }
 
     #[test]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -348,7 +348,7 @@ export const PRESETS: ProviderPreset[] = [
     id: 'opencode-zen', name: 'OpenCode Zen', protocol: 'openai', base_url: 'https://opencode.ai/zen/v1',
     defaultModels: [
       ['kimi-k3', 'openai'], ['kimi-k2.7-code', 'openai'], ['glm-5.2', 'openai'],
-      ['deepseek-v4-pro', 'openai'], ['deepseek-v4-flash', 'responses'], ['minimax-m3', 'openai'],
+      ['deepseek-v4-pro', 'openai'], ['deepseek-v4-flash', 'openai'], ['minimax-m3', 'openai'],
       ['claude-sonnet-5', 'anthropic'], ['claude-opus-5', 'anthropic'],
       ['claude-haiku-4-5', 'anthropic'], ['qwen3.7-plus', 'anthropic'],
       ['gpt-5.5', 'responses'], ['gpt-5.4-mini', 'responses'],

--- a/src/types/presets.test.ts
+++ b/src/types/presets.test.ts
@@ -33,10 +33,9 @@ describe('PRESETS', () => {
     }
   })
 
-  it('keeps the verified Responses dialect for DeepSeek flash on both OpenCode gateways', () => {
-    for (const preset of PRESETS.filter((p) => p.base_url.includes('opencode.ai'))) {
-      expect(preset.defaultModels).toContainEqual(['deepseek-v4-flash', 'responses'])
-    }
+  it('keeps the verified DeepSeek flash dialect per OpenCode gateway', () => {
+    expect(PRESETS.find((p) => p.id === 'opencode-zen')?.defaultModels).toContainEqual(['deepseek-v4-flash', 'openai'])
+    expect(PRESETS.find((p) => p.id === 'opencode-go')?.defaultModels).toContainEqual(['deepseek-v4-flash', 'responses'])
   })
 
   it('keeps preset ids unique and models unrepeated', () => {


### PR DESCRIPTION
## Summary

`opencode-zen/deepseek-v4-flash` returned **HTTP 502** on every request routed through the proxy, even though the same model id works directly against the OpenCode CLI. The Zen gateway (`https://opencode.ai/zen/v1`) only serves the flash tier over `/v1/chat/completions`; `/v1/responses` returns **500** even though the id is in the catalog. The Go gateway (`/zen/go/v1`) keeps the Responses API for the same id because that is the dialect its gateway exposes, so the two presets no longer share the dialect split.

A single 500 from the upstream flipped the key into the in-memory keypool cooldown (60s -> 300s -> 1500s backoff). Every retry during the cooldown hit `every enabled key is cooling down after recent failures` and surfaced as 502 to the client. The flash tier accumulated **25 errors / 0 successes** in `~/.loomrouter/loom.db` while `deepseek-v4-pro` (Chat Completions) answered normally.

On a separate axis, every `codex exec` spawned by `loomrouter_subagents` from the Tauri app cwd (for example `/Users/fabiohr/Projects/cardapya` when no `.git` is present) is refused by the `codex-cli >= 0.153` trust check with `Not inside a trusted directory and --skip-git-repo-check was not specified`. The parent's interactive Codex trust does not propagate to `Command::new`, so restarting or re-trusting the user's local session never heals the workers. The model fix above is irrelevant until a worker can spawn at all.

## What changed

Four commits on `fix/opencode-zen-flash-chat-completions`:

### Commit 1 - preset and dialect repair

- **`src-tauri/src/providers.rs`** -- `opencode-zen` preset: flip `deepseek-v4-flash` from `ProviderProtocol::Responses` to `ProviderProtocol::OpenAI`. Rewrite the adjacent comment block to document the verified Zen vs Go behaviour so the next reader does not re-merge the two presets by mistake.
- **`src-tauri/src/config.rs`** -- `repair_known_opencode_dialects`: scope the forced Responses repair to `opencode-go` only. Zen is deliberately excluded so the next `AppConfig::load` does not rewrite the new preset back to Responses. The `// why` comment now explains the asymmetry.
- **`src-tauri/src/proxy/tests_routing.rs`** -- new test `zen_preset_dispatches_deepseek_v4_flash_over_chat_completions`. Reads the shipped `PRESETS` and asserts that `opencode-zen/deepseek-v4-flash` dispatches via `("chat/completions", UpstreamKind::OpenAiChat)` while `opencode-go/deepseek-v4-flash` still goes through `("responses", UpstreamKind::Responses)`.

### Commit 2 - broadened runtime override at dispatch

The first iteration of the runtime override hardcoded a single `(provider, model)` pair. A user review pointed out that the same failure mode can hit every other model on Zen and Go: a stale persisted protocol (or a probe that ran while the upstream was misbehaving) silently downgrades the dispatch to the wrong dialect. The preset ships an explicit dialect split per model for both gateways, so it is the verified source of truth.

- **`src-tauri/src/proxy/routing.rs`** -- `model_protocol` now consults the preset first for any provider flagged by `is_multi_dialect_provider` (currently `opencode-zen` and `opencode-go`). When the preset lists the model with `protocol: Some(_)`, that wins. Otherwise the function falls through to the persisted `ProviderModel.protocol`, then to the provider default. Single-dialect providers keep their existing behaviour: the persisted override is respected.
- **`src-tauri/src/proxy/tests_routing.rs`** -- replaces `zen_flash_protocol_override_survives_a_persisted_responses` with `multi_dialect_preset_overrides_persisted_protocol`, which:
  - Iterates every model on Zen, sets `protocol = Responses` on the persisted provider, and asserts the preset still wins for each one.
  - Repeats the same sabotage on Go (with `OpenAI`) and asserts the preset still wins.
  - Verifies a hand-built single-dialect provider falls through to its persisted protocol, and then to the provider default when `protocol` is `None`.

### Commit 3 - `codex trust` audit and `is_multi_dialect_provider` ergonomics

Tracked as `fix(opencode-zen): trust the preset for every multi-dialect model`. The runtime rule from commit 2 keeps the surface minimal but the comment block now spells out exactly which providers are trusted at dispatch and why adding a new provider to that set is a deliberate decision rather than an accidental merge.

### Commit 4 - `--skip-git-repo-check` on every spawned worker

Root cause is one layer above the upstream: `codex-cli >= 0.153` requires the cwd of every `codex exec` invocation to be a trusted git directory, or the call must pass `--skip-git-repo-check`. LoomRouter spawns workers from the Tauri app cwd (e.g. `.../LoomRouter.app/Contents/MacOS/`), which is neither a git repo nor a trusted directory, and the trust applied to the user's interactive session does not propagate through `Command::new`.

- **`src-tauri/src/codex/subagents.rs`** -- `codex_task_args` gains `"--skip-git-repo-check"` immediately after `"exec"`. The flag is an `exec` subcommand option, so it must follow `exec` in argv; the comment above the literal documents why the bypass is safe (LoomRouter's own `--sandbox` and `--ask-for-approval never` remain the real guardrails).
- **`src-tauri/src/codex/subagents.rs`** -- existing assertion in `codex_global_options_precede_exec_subcommand` is updated to expect the new flag in the post-`exec` slice, so the global vs subcommand boundary is still covered.
- **`src-tauri/src/codex/subagents.rs`** -- new test `subagent_exec_invokes_codex_with_skip_git_repo_check` guards the flag placement (`skip > exec`) and the regression boundary (`approval < exec`). A future refactor that moves the flag before `exec` (turning it into a global option with different semantics) trips the assertion immediately.

No other flags were added. The bypass is surgical to one argv slot, with the rationale captured as a `// why` comment rather than a config knob.

## Why the layers

| Layer | Stops |
|-------|-------|
| Preset flip (commit 1) | A new install picking up the wrong dialect from the seed list. |
| `repair_known_opencode_dialects` scoped to Go (commit 1) | The next `AppConfig::load` rewriting Zen back to Responses. |
| Preset-trusted `model_protocol` (commit 2/3) | Any future config overwrite (probe, picker, backup restore, manual edit) for every multi-dialect model, not just the flash. |
| `--skip-git-repo-check` on every spawned worker (commit 4) | Every `codex exec` from a non-trusted cwd being refused at the trust gate before LoomRouter's own guardrails can apply. |

The preset trust at dispatch is the durable one for the dialect question. Layers 1 and 2 keep fresh installs and migrations correct; layer 3 survives any rewrite that slips past them. Layer 4 is independent of the dialect work: without it, no worker can spawn, so none of the upstream model routing ever runs. Both fixes are required to take `opencode-zen/deepseek-v4-flash` from "fails on first call" to "completes a worker turn."

## Verification

```bash
cargo fmt --manifest-path src-tauri/Cargo.toml --check
cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path src-tauri/Cargo.toml --lib   # 488 passed, 0 failed
bun run lint                                              # clean
```

New tests:

```
test proxy::tests_routing::zen_preset_dispatches_deepseek_v4_flash_over_chat_completions ... ok
test proxy::tests_routing::multi_dialect_preset_overrides_persisted_protocol ... ok
test codex::subagents::tests::subagent_exec_invokes_codex_with_skip_git_repo_check ... ok
```

## Manual smoke test (verified by maintainer)

1. Quit LoomRouter (tray -> Quit, not just close the window) so the in-memory keypool cooldown clears and any in-flight `codex exec` is reaped.
2. Launch and run a session with model `opencode-zen/deepseek-v4-flash`.
3. Observe HTTP 200 and `status = 'ok'` for the request in `~/.loomrouter/loom.db`, and confirm the worker no longer fails with `Not inside a trusted directory` in the session log.

Result on the maintainer machine: the request at `2026-09-03 09:53:48` is the first `status='ok'` entry for `opencode-zen/deepseek-v4-flash` after a stretch of 25 consecutive errors. The follow-up broadening commit was developed without re-running the binary against live traffic because the runtime rule is a strict superset of the previous one.

## Out of scope

- The keypool cooldown itself: the existing ladder (60s -> 300s -> 1500s) is intentional and documented in `src-tauri/src/keypool.rs`. Surfacing the cooldown time-to-recovery in the UI would be a separate change.
- Other Zen models: only `deepseek-v4-flash` was observed failing on Responses. The preset fix flips that one; the runtime rule covers every other model that may join the same failure class without another code change.
- Surfacing the `codex` trust decision to the user in the LoomRouter UI: today it is silently bypassed via `--skip-git-repo-check` because LoomRouter already enforces sandbox and approval, but a future change may want to mirror the user's interactive trust choice into spawned workers.
- Trusting the spawned worker's cwd explicitly (`codex --trust <cwd>` on the user's behalf) is rejected by `codex-cli` itself when the cwd is not a git repository, so the bypass flag is the only currently supported path.
