### PR TITLE
feat(codex): refresh native catalog periodically

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,10 +17,10 @@
         "@tauri-apps/plugin-updater": "^2.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^1.35.0",
+        "lucide-react": "^1.37.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router": "^7.6.1",
+        "react-router": "^7.18.3",
         "tailwind-merge": "^3.4.0",
       },
       "devDependencies": {
@@ -28,7 +28,7 @@
         "@tailwindcss/postcss": "^4.3.3",
         "@tauri-apps/cli": "^2.11.4",
         "@testing-library/jest-dom": "^7.0.1",
-        "@testing-library/react": "^16.3.2",
+        "@testing-library/react": "^16.3.3",
         "@testing-library/user-event": "^14.6.6",
         "@types/node": "^26.4.0",
         "@types/react": "^19.2.5",
@@ -321,7 +321,7 @@
 
     "@testing-library/jest-dom": ["@testing-library/jest-dom@7.0.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" }, "peerDependencies": { "@testing-library/dom": ">=10 <11", "vitest": ">= 0.32" }, "optionalPeers": ["vitest"] }, "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw=="],
 
-    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+    "@testing-library/react": ["@testing-library/react@16.3.3", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg=="],
 
     "@testing-library/user-event": ["@testing-library/user-event@14.6.6", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw=="],
 
@@ -577,7 +577,7 @@
 
     "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
-    "lucide-react": ["lucide-react@1.35.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yXCCWxGFYT6bLIPYC4SY6fPQPRs/d797rRIue+J9XP2Td6vQvD53gaQRBCnIVT1kTQRHtAtxlfOQNWAuIF8ELg=="],
+    "lucide-react": ["lucide-react@1.37.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LPsB4rD1TD6wZu1djKOf9vUnS1jTNaHbolXebXDgiTdb6jeA1agIJhJsIybCmjKmQClcOaal1o1OaiYahEftyQ=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -637,7 +637,7 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-router": ["react-router@7.18.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg=="],
+    "react-router": ["react-router@7.18.3", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "@tauri-apps/plugin-updater": "^2.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^1.35.0",
+    "lucide-react": "^1.37.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router": "^7.6.1",
+    "react-router": "^7.18.3",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
@@ -36,7 +36,7 @@
     "@tailwindcss/postcss": "^4.3.3",
     "@tauri-apps/cli": "^2.11.4",
     "@testing-library/jest-dom": "^7.0.1",
-    "@testing-library/react": "^16.3.2",
+    "@testing-library/react": "^16.3.3",
     "@testing-library/user-event": "^14.6.6",
     "@types/node": "^26.4.0",
     "@types/react": "^19.2.5",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -190,13 +190,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
 dependencies = [
  "async-channel",
  "async-task",
@@ -503,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -554,12 +554,12 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -577,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -622,9 +622,9 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cookie"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+checksum = "1a373e3602691c3cdea496d2f0ee5935151e6168fe87739483c463db1b2f2f87"
 dependencies = [
  "time",
  "version_check",
@@ -681,18 +681,18 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -792,12 +792,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.24.0",
- "darling_macro 0.24.0",
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -829,15 +829,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -864,20 +864,20 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.24.0",
+ "darling_core 0.24.1",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "dbus"
@@ -888,6 +888,37 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1024,7 +1055,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1259,18 +1290,19 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1303,7 +1335,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1390,7 +1422,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1720,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1730,7 +1762,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -1860,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1955,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1969,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1982,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1996,16 +2028,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2016,15 +2049,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2075,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2146,6 +2179,59 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -2234,9 +2320,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2358,9 +2444,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
 ]
@@ -2384,9 +2470,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -2399,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loom-router"
@@ -2505,6 +2591,16 @@ name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2850,9 +2946,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "open"
-version = "5.4.0"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b3d059e795d52b8a72fef45658620edd4d9c359b338564aa14391ffa511ed5"
+checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
 dependencies = [
  "dunce",
  "is-wsl",
@@ -3033,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
@@ -3044,7 +3140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "quick-xml",
  "serde",
  "time",
@@ -3060,7 +3156,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3073,7 +3169,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -3091,10 +3187,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "potential_utf"
-version = "0.1.5"
+name = "portable-atomic"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -3213,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "getrandom 0.4.3",
@@ -3351,22 +3462,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3501,7 +3612,7 @@ dependencies = [
  "base64 0.23.1",
  "chrono",
  "futures",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "pastey",
  "pin-project-lite",
  "rmcp-macros",
@@ -3522,11 +3633,11 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
- "darling 0.24.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3647,9 +3758,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3748,7 +3859,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals 0.30.0",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3848,7 +3959,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3870,7 +3981,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3905,7 +4016,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3940,16 +4051,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
  "serde_core",
@@ -3960,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4030,7 +4142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -4213,9 +4325,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4057c98e2e852d51fdcfca832aac7b571f6b351ad159f9eda5db1655f8d0c4d7"
+checksum = "e45c444e496845d3f2a351146bff59aae4975b2280238df1dfaa0c7d1846f38e"
 dependencies = [
  "base64 0.21.7",
  "serde",
@@ -4245,9 +4357,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4708,7 +4820,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4752,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4800,7 +4912,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4868,7 +4980,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -4883,7 +4995,7 @@ version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -4925,7 +5037,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -4936,7 +5048,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -4949,7 +5061,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -5338,9 +5450,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5351,9 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5361,9 +5473,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5371,9 +5483,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5384,9 +5496,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -5419,9 +5531,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5439,9 +5551,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -6074,9 +6186,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wry"
@@ -6178,9 +6290,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6213,14 +6325,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.18.0"
+version = "5.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -6238,19 +6350,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.55"
+name = "zcheapstr"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6286,9 +6407,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6297,9 +6418,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6308,13 +6429,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6325,9 +6446,15 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "memchr",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
@@ -6365,40 +6492,41 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.13.1"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "winnow 1.0.4",
+ "zcheapstr",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.13.1"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.5.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.119",
+ "syn 3.0.4",
  "winnow 1.0.4",
 ]

--- a/src-tauri/src/codex.rs
+++ b/src-tauri/src/codex.rs
@@ -54,8 +54,8 @@ mod config_patch;
 #[path = "codex/subagents.rs"]
 mod subagents;
 pub use config_patch::{
-    active_slug, apply, current_root_model, multi_agent_enabled, owns_slug, published_slug, remove,
-    set_multi_agent, BEGIN_MARK, END_MARK,
+    active_slug, apply, current_root_model, multi_agent_enabled, owns_slug, published_slug,
+    refresh_native_catalog_if_changed, remove, set_multi_agent, BEGIN_MARK, END_MARK,
 };
 pub use subagents::serve_subagent_mcp;
 

--- a/src-tauri/src/codex/config_patch.rs
+++ b/src-tauri/src/codex/config_patch.rs
@@ -123,16 +123,7 @@ pub fn apply(config: &AppConfig, port: u16) -> anyhow::Result<()> {
     // the previous capture (or an empty set with a warning). In native slug
     // mode our own bare slugs echo back through `debug models`, so exclude
     // every enabled external model id from the capture.
-    let exclude: std::collections::HashSet<String> = if config.native_slug_mode {
-        config
-            .providers
-            .values()
-            .filter(|p| p.enabled)
-            .flat_map(|p| p.models.iter().filter(|m| m.enabled).map(|m| m.id.clone()))
-            .collect()
-    } else {
-        std::collections::HashSet::new()
-    };
+    let exclude = native_catalog_exclusions(config);
     if codex_bin().is_some() {
         if let Err(e) = capture_native_catalog(&exclude) {
             tracing::warn!("native catalog capture failed, reusing previous: {e}");
@@ -142,7 +133,41 @@ pub fn apply(config: &AppConfig, port: u16) -> anyhow::Result<()> {
     }
     let native = load_native_catalog();
 
-    let catalog = build_merged_catalog(config, &native);
+    write_merged_catalog(config, port, &native)
+}
+
+/// Fetch the native Codex catalog and rebuild the integration only when the
+/// model data changed. The scheduled caller uses this instead of `apply` so
+/// an unchanged catalog never rewrites the user's Codex configuration.
+pub fn refresh_native_catalog_if_changed(config: &AppConfig, port: u16) -> anyhow::Result<bool> {
+    if codex_bin().is_none() {
+        tracing::warn!("Codex CLI not found; skipping native model catalog refresh");
+        return Ok(false);
+    }
+    std::fs::create_dir_all(loom_dir())?;
+    let previous = load_native_catalog();
+    let current = capture_native_catalog(&native_catalog_exclusions(config))?;
+    if current == previous {
+        return Ok(false);
+    }
+    write_merged_catalog(config, port, &current)?;
+    Ok(true)
+}
+
+fn native_catalog_exclusions(config: &AppConfig) -> std::collections::HashSet<String> {
+    if !config.native_slug_mode {
+        return std::collections::HashSet::new();
+    }
+    config
+        .providers
+        .values()
+        .filter(|p| p.enabled)
+        .flat_map(|p| p.models.iter().filter(|m| m.enabled).map(|m| m.id.clone()))
+        .collect()
+}
+
+fn write_merged_catalog(config: &AppConfig, port: u16, native: &Value) -> anyhow::Result<()> {
+    let catalog = build_merged_catalog(config, native);
     let model_count = catalog
         .get("models")
         .and_then(Value::as_array)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,24 @@ mod tray;
 use state::AppState;
 use tauri::Manager;
 
+const NATIVE_CATALOG_REFRESH_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(15 * 60);
+
+fn schedule_native_catalog_refresh(app: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        // Startup performs the first capture. Start the interval afterward so
+        // the periodic request is exactly every 15 minutes, not twice at launch.
+        let start = tokio::time::Instant::now() + NATIVE_CATALOG_REFRESH_INTERVAL;
+        let mut interval = tokio::time::interval_at(start, NATIVE_CATALOG_REFRESH_INTERVAL);
+        loop {
+            interval.tick().await;
+            app.state::<AppState>()
+                .refresh_codex_integration_if_changed()
+                .await;
+        }
+    });
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tracing_subscriber::fmt()
@@ -73,6 +91,7 @@ pub fn run() {
                 // launches. Refresh our generated files before the proxy
                 // starts so the picker cannot remain stuck on an old capture.
                 state.repair_codex_integration().await;
+                schedule_native_catalog_refresh(handle.clone());
                 if let Err(e) = state.server_start().await {
                     tracing::warn!("proxy autostart failed: {e}");
                 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,9 +35,7 @@ fn schedule_native_catalog_refresh(app: tauri::AppHandle) {
         let mut interval = tokio::time::interval_at(start, NATIVE_CATALOG_REFRESH_INTERVAL);
         loop {
             interval.tick().await;
-            app.state::<AppState>()
-                .refresh_codex_integration_if_changed()
-                .await;
+            app.state::<AppState>().refresh_all_model_catalogs().await;
         }
     });
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1122,6 +1122,32 @@ mod tests {
 
         assert!(!repaired);
     }
+
+    #[tokio::test]
+    async fn periodic_catalog_refresh_invalidates_picker_cache_when_models_change() {
+        // This catches a regression where the background refresh writes a
+        // newly released native model but the picker keeps serving an old
+        // in-memory slug list until LoomRouter restarts.
+        let config = AppConfig {
+            codex_integration: true,
+            port: 4242,
+            ..AppConfig::default()
+        };
+        let state = state_with_config(config);
+        *state.native_slugs_cache.write().await = Some(vec!["gpt-5.6-sol".into()]);
+
+        let changed = state
+            .refresh_codex_integration_if_changed_with(|config, port| {
+                assert!(config.codex_integration);
+                assert_eq!(port, 4242);
+                Ok(true)
+            })
+            .await
+            .unwrap();
+
+        assert!(changed);
+        assert!(state.native_slugs_cache.read().await.is_none());
+    }
     #[tokio::test]
     async fn codex_native_models_uses_populated_cache_when_server_is_present() {
         // The cache is already populated, so this path must return before the

--- a/src-tauri/src/state/lifecycle.rs
+++ b/src-tauri/src/state/lifecycle.rs
@@ -101,6 +101,15 @@ impl AppState {
         }
     }
 
+    /// Refresh every configured catalog in one scheduler tick. A provider
+    /// update re-applies Codex and captures its native models as part of that
+    /// write, so probing native models again would duplicate the same work.
+    pub async fn refresh_all_model_catalogs(&self) {
+        if !self.refresh_enabled_provider_model_catalogs().await {
+            self.refresh_codex_integration_if_changed().await;
+        }
+    }
+
     pub(super) async fn refresh_codex_integration_if_changed_with<F>(
         &self,
         refresh: F,

--- a/src-tauri/src/state/lifecycle.rs
+++ b/src-tauri/src/state/lifecycle.rs
@@ -83,6 +83,43 @@ impl AppState {
         Ok(true)
     }
 
+    /// Poll Codex's live model list without rewriting the integration when
+    /// it has not changed. New native models can ship while LoomRouter stays
+    /// open, so startup-only repair leaves the picker behind the release.
+    pub async fn refresh_codex_integration_if_changed(&self) {
+        match self
+            .refresh_codex_integration_if_changed_with(|config, port| {
+                codex::refresh_native_catalog_if_changed(&config, port)
+            })
+            .await
+        {
+            Ok(true) => {
+                tracing::info!("Codex integration catalog refreshed after native model update")
+            }
+            Ok(false) => {}
+            Err(e) => tracing::warn!("periodic native model catalog refresh failed: {e}"),
+        }
+    }
+
+    pub(super) async fn refresh_codex_integration_if_changed_with<F>(
+        &self,
+        refresh: F,
+    ) -> anyhow::Result<bool>
+    where
+        F: FnOnce(AppConfig, u16) -> anyhow::Result<bool> + Send + 'static,
+    {
+        let cfg = self.config.read().await.clone();
+        if !cfg.codex_integration {
+            return Ok(false);
+        }
+        let port = cfg.port;
+        let changed = tokio::task::spawn_blocking(move || refresh(cfg, port)).await??;
+        if changed {
+            self.invalidate_native_slugs_cache().await;
+        }
+        Ok(changed)
+    }
+
     /// Replaces `keys` wholesale, which is what the key manager means when it
     /// deletes the last key. So a caller that builds a Provider without
     /// populating `keys` ERASES every stored credential: the Edit Provider

--- a/src-tauri/src/state/model_discovery.rs
+++ b/src-tauri/src/state/model_discovery.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 /// Public model-limit catalog (the same source OpenCode uses for its model
 /// limits), used when a provider's own `/models` publishes no context window.
 const MODELS_DEV_URL: &str = "https://models.dev/api.json";
-const MODELS_DEV_TTL: std::time::Duration = std::time::Duration::from_secs(3600);
+const MODELS_DEV_TTL: std::time::Duration = std::time::Duration::from_secs(15 * 60);
 
 impl AppState {
     /// Fetch the native Codex model slugs for the model pickers. Returns a
@@ -113,14 +113,87 @@ impl AppState {
         )
     }
 
+    async fn model_catalog_for_provider(
+        &self,
+        provider: &crate::config::Provider,
+    ) -> anyhow::Result<Vec<(String, Option<u32>)>> {
+        if provider.id != crate::providers::CLAUDE_CODE_PROVIDER_ID {
+            return list_models_detailed(provider).await;
+        }
+
+        let mut models: HashMap<String, Option<u32>> = crate::providers::CLAUDE_CODE_MODELS
+            .iter()
+            .map(|(id, context, _)| (id.to_string(), Some(*context)))
+            .collect();
+        if let Some(entries) = self.models_dev_catalog().await.and_then(|catalog| {
+            catalog
+                .get("anthropic")
+                .and_then(|provider| provider.get("models"))
+                .and_then(serde_json::Value::as_object)
+                .cloned()
+        }) {
+            for (id, model) in entries {
+                if id.starts_with("claude-") {
+                    models.insert(id, entry_context_window(&model));
+                }
+            }
+        }
+        let mut models: Vec<_> = models.into_iter().collect();
+        models.sort_by(|(left, _), (right, _)| left.cmp(right));
+        Ok(models)
+    }
+
     /// Live model discovery: GET {base_url}/models (OpenAI-compatible).
     ///
     /// Beyond returning ids to the UI, this persists whatever context
     /// windows the catalog (or the models.dev fallback) publishes: existing
-    /// `ProviderModel` entries are filled in, and the rest is cached so
-    /// `toggle_model` can persist it when the model is enabled. Existing
-    /// values are kept — a hand-set override beats a later discovery.
+    /// `ProviderModel` entries are filled in, and new upstream models are
+    /// added enabled. Existing user choices are never overwritten.
     pub async fn discover_models(&self, provider_id: &str) -> anyhow::Result<Vec<String>> {
+        let (models, changed) = self.discover_models_without_persist(provider_id).await?;
+        if changed {
+            self.persist().await?;
+            self.maybe_auto_apply().await;
+        }
+        Ok(models)
+    }
+
+    /// Refresh every enabled provider once, committing the combined model
+    /// changes in one write and one Codex re-apply instead of once per API.
+    pub async fn refresh_enabled_provider_model_catalogs(&self) -> bool {
+        let provider_ids: Vec<String> = self
+            .config
+            .read()
+            .await
+            .providers
+            .values()
+            .filter(|provider| provider.enabled)
+            .map(|provider| provider.id.clone())
+            .collect();
+        let mut changed = false;
+        for provider_id in provider_ids {
+            match self.discover_models_without_persist(&provider_id).await {
+                Ok((_, updated)) => changed |= updated,
+                Err(error) => tracing::warn!(
+                    provider = %provider_id,
+                    "periodic provider model catalog refresh failed: {error}"
+                ),
+            }
+        }
+        if changed {
+            if let Err(error) = self.persist().await {
+                tracing::warn!("persisting periodic provider catalog refresh failed: {error}");
+                return false;
+            }
+            self.maybe_auto_apply().await;
+        }
+        changed
+    }
+
+    async fn discover_models_without_persist(
+        &self,
+        provider_id: &str,
+    ) -> anyhow::Result<(Vec<String>, bool)> {
         let provider = {
             let cfg = self.config.read().await;
             cfg.providers
@@ -128,7 +201,7 @@ impl AppState {
                 .cloned()
                 .ok_or_else(|| anyhow::anyhow!("unknown provider '{provider_id}'"))?
         };
-        let mut detailed = list_models_detailed(&provider).await?;
+        let mut detailed = self.model_catalog_for_provider(&provider).await?;
         let enabled_ids: Vec<String> = provider
             .models
             .iter()
@@ -177,41 +250,67 @@ impl AppState {
                 per_provider.insert(id.clone(), *ctx);
             }
         }
-        let mut updated = false;
-        {
+        let updated = {
             let mut cfg = self.config.write().await;
-            if let Some(p) = cfg.providers.get_mut(provider_id) {
-                for m in p.models.iter_mut() {
-                    let protocol = persisted_model_protocol(
-                        m.protocol.as_ref(),
-                        detected_protocols.get(&m.id),
-                    );
-                    if m.protocol != protocol {
-                        m.protocol = protocol;
-                        updated = true;
-                    }
-                    if let Some(vision_models) = &vision_models {
-                        let next = vision_models.contains(&m.id);
-                        if m.supports_vision != next {
-                            m.supports_vision = next;
-                            updated = true;
-                        }
-                    }
-                    if m.context_window.is_none() {
-                        if let Some((_, ctx)) = known.iter().find(|(id, _)| id == &m.id) {
-                            m.context_window = Some(*ctx);
-                            updated = true;
-                        }
-                    }
-                }
+            cfg.providers.get_mut(provider_id).is_some_and(|current| {
+                merge_discovered_models(
+                    current,
+                    &detailed,
+                    &detected_protocols,
+                    vision_models.as_ref(),
+                )
+            })
+        };
+        Ok((detailed.into_iter().map(|(id, _)| id).collect(), updated))
+    }
+}
+
+fn merge_discovered_models(
+    provider: &mut crate::config::Provider,
+    detailed: &[(String, Option<u32>)],
+    detected_protocols: &HashMap<String, crate::config::ProviderProtocol>,
+    vision_models: Option<&HashSet<String>>,
+) -> bool {
+    let mut changed = false;
+    for model in &mut provider.models {
+        let protocol =
+            persisted_model_protocol(model.protocol.as_ref(), detected_protocols.get(&model.id));
+        if model.protocol != protocol {
+            model.protocol = protocol;
+            changed = true;
+        }
+        if let Some(vision_models) = vision_models {
+            let next = vision_models.contains(&model.id);
+            if model.supports_vision != next {
+                model.supports_vision = next;
+                changed = true;
             }
         }
-        if updated {
-            self.persist().await?;
-            self.maybe_auto_apply().await;
+        if model.context_window.is_none() {
+            if let Some((_, context)) = detailed.iter().find(|(id, _)| id == &model.id) {
+                model.context_window = *context;
+                changed = true;
+            }
         }
-        Ok(detailed.into_iter().map(|(id, _)| id).collect())
     }
+    for (id, context_window) in detailed {
+        if provider.models.iter().any(|model| model.id == *id) {
+            continue;
+        }
+        provider.models.push(crate::config::ProviderModel {
+            id: id.clone(),
+            label: crate::providers::claude_code_label(id),
+            context_window: *context_window,
+            protocol: None,
+            fast_mode: crate::providers::claude_code_fast_mode(id),
+            enabled: true,
+            supports_vision: vision_models
+                .map(|models| models.contains(id))
+                .unwrap_or(provider.id == crate::providers::CLAUDE_CODE_PROVIDER_ID),
+        });
+        changed = true;
+    }
+    changed
 }
 
 /// The models.dev catalog key for one of our provider ids, where the two
@@ -235,6 +334,8 @@ fn models_dev_key(provider_id: &str) -> &str {
         // The coding endpoint advertises the full Z.AI catalog, which
         // models.dev publishes as `zai` rather than the provider slug.
         "zai"
+    } else if provider_id == crate::providers::CLAUDE_CODE_PROVIDER_ID {
+        "anthropic"
     } else {
         provider_id
     }
@@ -490,7 +591,7 @@ pub async fn list_models(p: &crate::config::Provider) -> anyhow::Result<Vec<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{AppConfig, ProviderProtocol};
+    use crate::config::{AppConfig, ProviderModel, ProviderProtocol};
     use serde_json::json;
 
     #[tokio::test]
@@ -501,6 +602,53 @@ mod tests {
         *state.models_dev.write().await = Some((std::time::Instant::now(), expected.clone()));
 
         assert_eq!(state.models_dev_catalog().await, Some(expected));
+    }
+
+    #[test]
+    fn catalog_sync_adds_new_models_enabled_without_changing_existing_choices() {
+        // This catches a regression where the periodic catalog refresh either
+        // hides a newly released model or overrides an explicit user choice
+        // for a model already in the provider.
+        let mut provider = crate::config::Provider {
+            id: "test".into(),
+            name: "Test".into(),
+            protocol: ProviderProtocol::OpenAI,
+            base_url: "https://example.test/v1".into(),
+            api_key: None,
+            keys: vec![],
+            rotation_enabled: false,
+            has_key: false,
+            context_window: None,
+            user_agent: None,
+            prompt_cache: None,
+            models: vec![ProviderModel {
+                id: "existing".into(),
+                label: None,
+                context_window: None,
+                protocol: None,
+                fast_mode: false,
+                enabled: false,
+                supports_vision: false,
+            }],
+            enabled: true,
+        };
+
+        let changed = merge_discovered_models(
+            &mut provider,
+            &[
+                ("existing".into(), Some(128_000)),
+                ("new-model".into(), Some(256_000)),
+            ],
+            &HashMap::new(),
+            None,
+        );
+
+        assert!(changed);
+        assert!(!provider.models[0].enabled);
+        assert_eq!(provider.models[0].context_window, Some(128_000));
+        assert_eq!(provider.models[1].id, "new-model");
+        assert!(provider.models[1].enabled);
+        assert_eq!(provider.models[1].context_window, Some(256_000));
     }
 
     #[test]

--- a/src-tauri/src/translate/stream.rs
+++ b/src-tauri/src/translate/stream.rs
@@ -58,13 +58,15 @@ pub struct StreamTranslator {
     text_acc: String,
     // reasoning item (thinking summaries, e.g. Kimi reasoning_content)
     rs_item_id: String,
+    rs_output_index: usize,
     rs_open: bool,
     rs_closed: bool,
     rs_text_acc: String,
     rs_details: Vec<Value>,
+    anthropic_thinking_blocks: BTreeSet<usize>,
     // tool calls keyed by upstream index
     tools: BTreeMap<usize, ToolCallState>,
-    next_tool_output_index: usize,
+    next_output_index: usize,
     usage: Option<Value>,
     finish_reason: Option<String>,
     /// `flattened tool name -> namespace`, from the request this stream is
@@ -103,12 +105,14 @@ impl StreamTranslator {
             msg_output_index: 0,
             text_acc: String::new(),
             rs_item_id: synthetic_id("rs"),
+            rs_output_index: 0,
             rs_open: false,
             rs_closed: false,
             rs_text_acc: String::new(),
             rs_details: Vec::new(),
+            anthropic_thinking_blocks: BTreeSet::new(),
             tools: BTreeMap::new(),
-            next_tool_output_index: 1,
+            next_output_index: 0,
             usage: None,
             finish_reason: None,
             tool_namespaces: BTreeMap::new(),
@@ -135,6 +139,12 @@ impl StreamTranslator {
     fn seq(&mut self) -> u64 {
         self.seq += 1;
         self.seq
+    }
+
+    fn allocate_output_index(&mut self) -> usize {
+        let index = self.next_output_index;
+        self.next_output_index += 1;
+        index
     }
 
     /// Translate one upstream SSE event into zero or more downstream frames.
@@ -321,7 +331,11 @@ impl StreamTranslator {
                 let block = data.get("content_block").cloned().unwrap_or(json!({}));
                 match block.get("type").and_then(Value::as_str) {
                     Some("text") => self.ensure_message_open(&mut out),
-                    Some("thinking") => self.ensure_started(&mut out),
+                    Some("thinking") => {
+                        self.ensure_started(&mut out);
+                        let idx = data.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
+                        self.anthropic_thinking_blocks.insert(idx);
+                    }
                     Some("tool_use") => {
                         let idx = data.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
                         self.on_tool_delta(
@@ -389,6 +403,13 @@ impl StreamTranslator {
                         .map(str::to_string);
                 }
             }
+            "content_block_stop" => {
+                let idx = data.get("index").and_then(Value::as_u64).unwrap_or(0) as usize;
+                if self.anthropic_thinking_blocks.remove(&idx) {
+                    self.close_reasoning(&mut out);
+                    self.reset_reasoning();
+                }
+            }
             "message_stop" => {
                 out.extend(self.close_all_and_complete());
             }
@@ -443,8 +464,7 @@ impl StreamTranslator {
             return;
         }
         self.msg_open = true;
-        // The reasoning item, when present, owns output_index 0.
-        self.msg_output_index = if self.rs_open { 1 } else { 0 };
+        self.msg_output_index = self.allocate_output_index();
         let index = self.msg_output_index;
         let seq = self.seq();
         out.push(OutFrame {
@@ -509,12 +529,14 @@ impl StreamTranslator {
         self.ensure_started(out);
         if !self.rs_open {
             self.rs_open = true;
+            self.rs_output_index = self.allocate_output_index();
+            let output_index = self.rs_output_index;
             let seq = self.seq();
             out.push(OutFrame {
                 event: Some("response.output_item.added".into()),
                 data: json!({
                     "type":"response.output_item.added","sequence_number":seq,
-                    "output_index":0,
+                    "output_index":output_index,
                     "item":{"id":self.rs_item_id,"type":"reasoning","status":"in_progress","summary":[]}
                 }),
                 done_marker: false,
@@ -524,7 +546,7 @@ impl StreamTranslator {
                 event: Some("response.reasoning_summary_part.added".into()),
                 data: json!({
                     "type":"response.reasoning_summary_part.added","sequence_number":seq,
-                    "item_id":self.rs_item_id,"output_index":0,"summary_index":0,
+                    "item_id":self.rs_item_id,"output_index":output_index,"summary_index":0,
                     "part":{"type":"summary_text","text":""}
                 }),
                 done_marker: false,
@@ -535,7 +557,7 @@ impl StreamTranslator {
             event: Some("response.reasoning_summary_text.delta".into()),
             data: json!({
                 "type":"response.reasoning_summary_text.delta","sequence_number":seq,
-                "item_id":self.rs_item_id,"output_index":0,"summary_index":0,
+                "item_id":self.rs_item_id,"output_index":self.rs_output_index,"summary_index":0,
                 "delta":text
             }),
             done_marker: false,
@@ -548,12 +570,13 @@ impl StreamTranslator {
             return;
         }
         self.rs_closed = true;
+        let output_index = self.rs_output_index;
         let seq = self.seq();
         out.push(OutFrame {
             event: Some("response.reasoning_summary_text.done".into()),
             data: json!({
                 "type":"response.reasoning_summary_text.done","sequence_number":seq,
-                "item_id":self.rs_item_id,"output_index":0,"summary_index":0,
+                "item_id":self.rs_item_id,"output_index":output_index,"summary_index":0,
                 "text":self.rs_text_acc
             }),
             done_marker: false,
@@ -563,7 +586,7 @@ impl StreamTranslator {
             event: Some("response.reasoning_summary_part.done".into()),
             data: json!({
                 "type":"response.reasoning_summary_part.done","sequence_number":seq,
-                "item_id":self.rs_item_id,"output_index":0,"summary_index":0,
+                "item_id":self.rs_item_id,"output_index":output_index,"summary_index":0,
                 "part":{"type":"summary_text","text":self.rs_text_acc}
             }),
             done_marker: false,
@@ -582,11 +605,19 @@ impl StreamTranslator {
             event: Some("response.output_item.done".into()),
             data: json!({
                 "type":"response.output_item.done","sequence_number":seq,
-                "output_index":0,
+                "output_index":output_index,
                 "item":item
             }),
             done_marker: false,
         });
+    }
+
+    fn reset_reasoning(&mut self) {
+        self.rs_item_id = synthetic_id("rs");
+        self.rs_open = false;
+        self.rs_closed = false;
+        self.rs_text_acc.clear();
+        self.rs_details.clear();
     }
 
     fn on_text_delta(&mut self, text: &str, out: &mut Vec<OutFrame>) {
@@ -627,17 +658,7 @@ impl StreamTranslator {
     ) {
         self.ensure_started(out);
         if !self.tools.contains_key(&idx) {
-            // Reserve 0 for reasoning (when present) and the next slot for
-            // the message item; tools come after both.
-            let output_index = if self.tools.is_empty() {
-                let base = if self.rs_open { 2 } else { 1 };
-                self.next_tool_output_index = base + 1;
-                base
-            } else {
-                let i = self.next_tool_output_index;
-                self.next_tool_output_index += 1;
-                i
-            };
+            let output_index = self.allocate_output_index();
             let state = ToolCallState {
                 item_id: synthetic_id("fc"),
                 call_id: call_id.to_string(),

--- a/src-tauri/src/translate/tests_a.rs
+++ b/src-tauri/src/translate/tests_a.rs
@@ -282,6 +282,95 @@ fn anthropic_thinking_blocks_produce_responses_reasoning_progress() {
 }
 
 #[test]
+fn anthropic_progress_items_complete_before_the_turn_finishes() {
+    let mut translator = StreamTranslator::new(
+        UpstreamKind::Anthropic,
+        DownstreamKind::Responses,
+        "claude-opus-5",
+    );
+    translator.push_event(
+        Some("message_start"),
+        &json!({"type":"message_start","message":{"usage":{"input_tokens":3}}}).to_string(),
+    );
+
+    let mut first = Vec::new();
+    for (name, data) in [
+        (
+            "content_block_start",
+            json!({"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}),
+        ),
+        (
+            "content_block_delta",
+            json!({"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Subagent started: Assets\n"}}),
+        ),
+        (
+            "content_block_stop",
+            json!({"type":"content_block_stop","index":0}),
+        ),
+    ] {
+        first.extend(translator.push_event(Some(name), &data.to_string()));
+    }
+    let first_done = first
+        .iter()
+        .find(|frame| {
+            frame.event.as_deref() == Some("response.output_item.done")
+                && frame.data["item"]["type"] == "reasoning"
+        })
+        .expect("a progress item must be visible before message_stop");
+    assert_eq!(
+        first_done.data["item"]["summary"][0]["text"],
+        "Subagent started: Assets\n"
+    );
+    assert!(
+        first
+            .iter()
+            .all(|frame| frame.event.as_deref() != Some("response.completed")),
+        "completing progress must not complete the Claude turn"
+    );
+
+    let mut second = Vec::new();
+    for (name, data) in [
+        (
+            "content_block_start",
+            json!({"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":""}}),
+        ),
+        (
+            "content_block_delta",
+            json!({"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"Subagent tool: Read\n"}}),
+        ),
+        (
+            "content_block_stop",
+            json!({"type":"content_block_stop","index":1}),
+        ),
+    ] {
+        second.extend(translator.push_event(Some(name), &data.to_string()));
+    }
+    let second_done = second
+        .iter()
+        .find(|frame| {
+            frame.event.as_deref() == Some("response.output_item.done")
+                && frame.data["item"]["type"] == "reasoning"
+        })
+        .expect("each later progress item must also complete immediately");
+    assert_ne!(
+        first_done.data["item"]["id"],
+        second_done.data["item"]["id"]
+    );
+    assert_ne!(
+        first_done.data["output_index"],
+        second_done.data["output_index"]
+    );
+
+    let terminal = translator.push_event(
+        Some("message_stop"),
+        &json!({"type":"message_stop"}).to_string(),
+    );
+    assert!(terminal
+        .iter()
+        .any(|frame| frame.event.as_deref() == Some("response.completed")));
+}
+
+#[test]
 fn responses_request_converts_tools_and_input() {
     let payload = json!({
         "model": "deepseek/deepseek-chat",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
-import pkg from './package.json'
+import pkg from './package.json' with { type: 'json' }
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -21,7 +21,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      "@": path.resolve(import.meta.dirname, "./src"),
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,12 +4,12 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
-import pkg from './package.json'
+import pkg from './package.json' with { type: 'json' }
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
-    alias: { '@': path.resolve(__dirname, './src') },
+    alias: { '@': path.resolve(import.meta.dirname, './src') },
   },
   define: {
     // Same injection as vite.config.ts: Layout renders __APP_VERSION__ and


### PR DESCRIPTION
## Summary
- Poll model catalogs every 15 minutes after startup.
- Sync every enabled HTTP provider from its models endpoint and add newly published models enabled.
- Sync Claude Code from the public Anthropic catalog.
- Rebuild the merged picker catalog only when native Codex models change.
- Preserve existing models and user enablement choices.

## Verification
- bun run test
- bun run build
- cargo fmt --manifest-path src-tauri/Cargo.toml --check
- cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path src-tauri/Cargo.toml
- bunx eslint . --ignore-pattern .worktrees/**

bun run lint still fails because the pre-existing .worktrees/prevent-sleep nested worktree is parsed as a second TypeScript project.