### PR TITLE
fix(codex): preserve expanded context behind proxy

### DIFF
--- a/src-tauri/src/codex/catalog.rs
+++ b/src-tauri/src/codex/catalog.rs
@@ -376,6 +376,15 @@ pub(super) fn ensure_native_catalog_backfills(catalog: &mut Value) {
     let Some(models) = catalog.get_mut("models").and_then(Value::as_array_mut) else {
         return;
     };
+    // Early Codex catalogs shipped Astra with Terra's 272k window. Keep the
+    // official 1.05M raw limit here so the 95% effective window is about 1M.
+    if let Some(astra) = models
+        .iter_mut()
+        .find(|model| model.get("slug").and_then(Value::as_str) == Some("gpt-6-astra"))
+    {
+        astra["context_window"] = json!(1_050_000);
+        astra["max_context_window"] = json!(1_050_000);
+    }
     if models
         .iter()
         .any(|model| model.get("slug").and_then(Value::as_str) == Some("gpt-5.6-sol"))

--- a/src-tauri/src/codex/catalog.rs
+++ b/src-tauri/src/codex/catalog.rs
@@ -49,8 +49,9 @@ pub fn capture_native_catalog(
     Ok(catalog)
 }
 
-/// Append models missing from the cached catalog and refresh context fields
-/// whose semantics can change with a newer Codex release.
+/// Append models missing from the cached catalog, refresh the capability
+/// fields a newer Codex release redefines, and fill in context windows the
+/// destination does not state yet.
 fn merge_cli_catalog(cache: &mut Value, cli: &Value) {
     let known: std::collections::HashSet<String> = cache
         .get("models")
@@ -74,12 +75,27 @@ fn merge_cli_catalog(cache: &mut Value, cli: &Value) {
                     .iter_mut()
                     .find(|entry| entry.get("slug").and_then(Value::as_str) == Some(slug))
                 {
+                    // Release semantics: whether expanded context exists at
+                    // all, and how much of the window Codex may fill. A newer
+                    // release is authoritative for both.
                     for field in [
-                        "context_window",
-                        "max_context_window",
                         "effective_context_window_percent",
                         "supports_experimental_context",
                     ] {
+                        if let Some(value) = model.get(field) {
+                            existing[field] = value.clone();
+                        }
+                    }
+                    // The windows themselves are entitlement, not release
+                    // semantics: the cache is Codex Desktop's record of what
+                    // this account was granted, and a bundled catalog
+                    // describes the binary. Fill a gap, never overwrite, or a
+                    // restricted account gets published a window it does not
+                    // have and Codex plans turns against it.
+                    for field in ["context_window", "max_context_window"] {
+                        if existing.get(field).is_some() {
+                            continue;
+                        }
                         if let Some(value) = model.get(field) {
                             existing[field] = value.clone();
                         }
@@ -121,10 +137,15 @@ fn capture_cli_catalog(exclude_slugs: &std::collections::HashSet<String>) -> any
             .ok()
             .and_then(|value| native_catalog_from_value(value, exclude_slugs).ok())
     };
-    // Both invocations, not one as the other's fallback. `--bundled` captures
-    // models and capabilities shipped by a newer CLI release even when the
-    // regular refresh echoes LoomRouter's current catalog. Neither source is
-    // complete alone.
+    // Both invocations, not one as the other's fallback. A plain `debug
+    // models` refreshes and reflects the account, but the managed block
+    // points `model_catalog_json` at our own merged file, so once the
+    // integration is applied Codex renders that file straight back at us:
+    // every capture after the first re-reads its own output, and a model or
+    // capability shipped by a newer Codex release can never enter.
+    // `--bundled` skips the refresh and dumps the catalog compiled into the
+    // binary, which is immune to that echo but knows nothing about the
+    // account. Neither is complete alone.
     let refreshed = run("");
     let refresh_error = refreshed.as_ref().err().map(|e| e.to_string());
     let refreshed = refreshed.ok().and_then(&parse);
@@ -382,25 +403,29 @@ pub(super) fn load_native_catalog() -> Value {
     catalog
 }
 
-/// Keep a release-known native entry available when an older or sandboxed
-/// Codex CLI omits it from `debug models`. Clone Terra's real schema instead
-/// of inventing one, so the picker gets the same contract Codex expects.
+/// Normalize the native catalog in the two ways the picker depends on.
+///
+/// Context: a model that declares `supports_experimental_context` publishes
+/// its advertised maximum as the live window, because Codex only turns
+/// expanded context on for its direct backend URL and LoomRouter is that
+/// backend's authenticated local proxy.
+///
+/// Backfill: keep a release-known native entry available when an older or
+/// sandboxed Codex CLI omits it from `debug models`. Clone Terra's real schema
+/// instead of inventing one, so the picker gets the same contract Codex
+/// expects.
 pub(super) fn ensure_native_catalog_backfills(catalog: &mut Value) {
     let Some(models) = catalog.get_mut("models").and_then(Value::as_array_mut) else {
         return;
     };
     for model in models.iter_mut() {
         // Codex enables expanded context only for its direct backend URL.
-        // LoomRouter is that backend's authenticated local proxy, so promote
-        // the advertised ceiling here instead of leaving proxied sessions at
-        // the smaller default window.
-        if model
-            .get("slug")
-            .and_then(Value::as_str)
-            .is_some_and(|slug| slug == "gpt-6-astra")
-        {
-            model["max_context_window"] = json!(1_050_000);
-        }
+        // LoomRouter is that backend's authenticated local proxy, so publish the
+        // ceiling the model itself advertises instead of leaving proxied
+        // sessions at the smaller default window. Only the advertised value:
+        // a model whose real ceiling differs from what the catalog reports is
+        // what `native_model_context_overrides` exists for, and inventing a
+        // number here would over-estimate the window Codex plans against.
         if model
             .get("supports_experimental_context")
             .and_then(Value::as_bool)

--- a/src-tauri/src/codex/catalog.rs
+++ b/src-tauri/src/codex/catalog.rs
@@ -38,7 +38,7 @@ pub fn capture_native_catalog(
         // only the CLI reports, so a cache that predates a model release
         // cannot pin the picker to the old set.
         (Some(mut cache), Ok(cli)) => {
-            merge_cli_only_models(&mut cache, &cli);
+            merge_cli_catalog(&mut cache, &cli);
             ensure_native_catalog_backfills(&mut cache);
             cache
         }
@@ -49,8 +49,9 @@ pub fn capture_native_catalog(
     Ok(catalog)
 }
 
-/// Append the models the CLI reports that the cache does not know about.
-fn merge_cli_only_models(cache: &mut Value, cli: &Value) {
+/// Append models missing from the cached catalog and refresh context fields
+/// whose semantics can change with a newer Codex release.
+fn merge_cli_catalog(cache: &mut Value, cli: &Value) {
     let known: std::collections::HashSet<String> = cache
         .get("models")
         .and_then(Value::as_array)
@@ -68,7 +69,24 @@ fn merge_cli_only_models(cache: &mut Value, cli: &Value) {
     let extras = cli.get("models").and_then(Value::as_array);
     for model in extras.into_iter().flatten() {
         match model.get("slug").and_then(Value::as_str) {
-            Some(slug) if !known.contains(slug) => target.push(model.clone()),
+            Some(slug) if known.contains(slug) => {
+                if let Some(existing) = target
+                    .iter_mut()
+                    .find(|entry| entry.get("slug").and_then(Value::as_str) == Some(slug))
+                {
+                    for field in [
+                        "context_window",
+                        "max_context_window",
+                        "effective_context_window_percent",
+                        "supports_experimental_context",
+                    ] {
+                        if let Some(value) = model.get(field) {
+                            existing[field] = value.clone();
+                        }
+                    }
+                }
+            }
+            Some(_) => target.push(model.clone()),
             _ => {}
         }
     }
@@ -103,22 +121,17 @@ fn capture_cli_catalog(exclude_slugs: &std::collections::HashSet<String>) -> any
             .ok()
             .and_then(|value| native_catalog_from_value(value, exclude_slugs).ok())
     };
-    // Both invocations, not one as the other's fallback. A plain `debug
-    // models` refreshes and reflects the account, but the managed block
-    // points `model_catalog_json` at our own merged file, so once the
-    // integration is applied Codex renders that file straight back at us:
-    // every capture after the first re-reads its own output, and a model
-    // shipped by a newer Codex release can never enter. `--bundled` skips the
-    // refresh and dumps the catalog compiled into the binary, which is immune
-    // to that echo but knows nothing about the account. Neither is complete
-    // alone.
+    // Both invocations, not one as the other's fallback. `--bundled` captures
+    // models and capabilities shipped by a newer CLI release even when the
+    // regular refresh echoes LoomRouter's current catalog. Neither source is
+    // complete alone.
     let refreshed = run("");
     let refresh_error = refreshed.as_ref().err().map(|e| e.to_string());
     let refreshed = refreshed.ok().and_then(&parse);
     let bundled = run("--bundled").ok().and_then(&parse);
     match (refreshed, bundled) {
         (Some(mut live), Some(bundled)) => {
-            merge_cli_only_models(&mut live, &bundled);
+            merge_cli_catalog(&mut live, &bundled);
             Ok(live)
         }
         (Some(only), None) | (None, Some(only)) => Ok(only),
@@ -376,14 +389,27 @@ pub(super) fn ensure_native_catalog_backfills(catalog: &mut Value) {
     let Some(models) = catalog.get_mut("models").and_then(Value::as_array_mut) else {
         return;
     };
-    // Early Codex catalogs shipped Astra with Terra's 272k window. Keep the
-    // official 1.05M raw limit here so the 95% effective window is about 1M.
-    if let Some(astra) = models
-        .iter_mut()
-        .find(|model| model.get("slug").and_then(Value::as_str) == Some("gpt-6-astra"))
-    {
-        astra["context_window"] = json!(1_050_000);
-        astra["max_context_window"] = json!(1_050_000);
+    for model in models.iter_mut() {
+        // Codex enables expanded context only for its direct backend URL.
+        // LoomRouter is that backend's authenticated local proxy, so promote
+        // the advertised ceiling here instead of leaving proxied sessions at
+        // the smaller default window.
+        if model
+            .get("slug")
+            .and_then(Value::as_str)
+            .is_some_and(|slug| slug == "gpt-6-astra")
+        {
+            model["max_context_window"] = json!(1_050_000);
+        }
+        if model
+            .get("supports_experimental_context")
+            .and_then(Value::as_bool)
+            == Some(true)
+        {
+            if let Some(max) = model.get("max_context_window").and_then(Value::as_i64) {
+                model["context_window"] = json!(max);
+            }
+        }
     }
     if models
         .iter()

--- a/src-tauri/src/codex/catalog/tests.rs
+++ b/src-tauri/src/codex/catalog/tests.rs
@@ -123,6 +123,8 @@ fn native_catalog_backfills_sol_from_terra_when_the_cli_omits_it() {
 
 #[test]
 fn bundled_catalog_refreshes_context_capabilities_of_existing_models() {
+    // The bundled catalog owns the capability flags; the account entry owns
+    // any window it already states, and only gaps get filled.
     let mut live = json!({"models": [{
         "slug": "gpt-future", "description": "Account-specific",
         "context_window": 272_000
@@ -156,7 +158,10 @@ fn experimental_native_models_use_their_maximum_behind_the_proxy() {
 }
 
 #[test]
-fn astra_uses_its_official_raw_context_behind_the_proxy() {
+fn astra_uses_the_ceiling_it_advertises_behind_the_proxy() {
+    // No per-slug constant: the published window is whatever the catalog
+    // reports, so a newer release that raises or lowers the ceiling lands.
+    // Tuning a specific model is what `native_model_context_overrides` is for.
     let mut native = json!({"models": [
         {"slug": "gpt-6-astra", "context_window": 272_000,
          "max_context_window": 872_000, "supports_experimental_context": true,
@@ -165,8 +170,8 @@ fn astra_uses_its_official_raw_context_behind_the_proxy() {
 
     ensure_native_catalog_backfills(&mut native);
 
-    assert_eq!(native["models"][0]["context_window"], 1_050_000);
-    assert_eq!(native["models"][0]["max_context_window"], 1_050_000);
+    assert_eq!(native["models"][0]["context_window"], 872_000);
+    assert_eq!(native["models"][0]["max_context_window"], 872_000);
 }
 
 #[test]

--- a/src-tauri/src/codex/catalog/tests.rs
+++ b/src-tauri/src/codex/catalog/tests.rs
@@ -122,6 +122,21 @@ fn native_catalog_backfills_sol_from_terra_when_the_cli_omits_it() {
 }
 
 #[test]
+fn native_catalog_corrects_astra_context_from_stale_codex_cache() {
+    let mut native = json!({"models": [
+        {"slug": "gpt-6-astra", "context_window": 272_000,
+         "max_context_window": 272_000, "effective_context_window_percent": 95}
+    ]});
+
+    ensure_native_catalog_backfills(&mut native);
+
+    let astra = &native["models"][0];
+    assert_eq!(astra["context_window"], 1_050_000);
+    assert_eq!(astra["max_context_window"], 1_050_000);
+    assert_eq!(astra["effective_context_window_percent"], 95);
+}
+
+#[test]
 fn kimi_heuristic_applies_only_to_kimi_family() {
     let mut cfg = demo_config();
     let kimi = crate::providers::PRESETS

--- a/src-tauri/src/codex/catalog/tests.rs
+++ b/src-tauri/src/codex/catalog/tests.rs
@@ -122,18 +122,51 @@ fn native_catalog_backfills_sol_from_terra_when_the_cli_omits_it() {
 }
 
 #[test]
-fn native_catalog_corrects_astra_context_from_stale_codex_cache() {
+fn bundled_catalog_refreshes_context_capabilities_of_existing_models() {
+    let mut live = json!({"models": [{
+        "slug": "gpt-future", "description": "Account-specific",
+        "context_window": 272_000
+    }]});
+    let bundled = json!({"models": [{
+        "slug": "gpt-future", "description": "Bundled",
+        "context_window": 272_000, "max_context_window": 600_000,
+        "supports_experimental_context": true
+    }]});
+
+    merge_cli_catalog(&mut live, &bundled);
+
+    let model = &live["models"][0];
+    assert_eq!(model["description"], "Account-specific");
+    assert_eq!(model["max_context_window"], 600_000);
+    assert_eq!(model["supports_experimental_context"], true);
+}
+
+#[test]
+fn experimental_native_models_use_their_maximum_behind_the_proxy() {
     let mut native = json!({"models": [
-        {"slug": "gpt-6-astra", "context_window": 272_000,
-         "max_context_window": 272_000, "effective_context_window_percent": 95}
+        {"slug": "gpt-future", "context_window": 272_000,
+         "max_context_window": 600_000, "supports_experimental_context": true,
+         "effective_context_window_percent": 95}
     ]});
 
     ensure_native_catalog_backfills(&mut native);
 
-    let astra = &native["models"][0];
-    assert_eq!(astra["context_window"], 1_050_000);
-    assert_eq!(astra["max_context_window"], 1_050_000);
-    assert_eq!(astra["effective_context_window_percent"], 95);
+    assert_eq!(native["models"][0]["context_window"], 600_000);
+    assert_eq!(native["models"][0]["max_context_window"], 600_000);
+}
+
+#[test]
+fn astra_uses_its_official_raw_context_behind_the_proxy() {
+    let mut native = json!({"models": [
+        {"slug": "gpt-6-astra", "context_window": 272_000,
+         "max_context_window": 872_000, "supports_experimental_context": true,
+         "effective_context_window_percent": 95}
+    ]});
+
+    ensure_native_catalog_backfills(&mut native);
+
+    assert_eq!(native["models"][0]["context_window"], 1_050_000);
+    assert_eq!(native["models"][0]["max_context_window"], 1_050_000);
 }
 
 #[test]
@@ -521,7 +554,7 @@ fn bundled_models_survive_a_refresh_that_only_echoes_our_own_catalog() {
         {"slug": "gpt-5.6-terra", "display_name": "GPT-5.6-Terra", "priority": 2}
     ]});
 
-    merge_cli_only_models(&mut echoed, &bundled);
+    merge_cli_catalog(&mut echoed, &bundled);
 
     let slugs: Vec<&str> = echoed["models"]
         .as_array()


### PR DESCRIPTION
Codex only activates experimental context when the provider URL points directly at its native backend. LoomRouter uses an authenticated localhost proxy, so capable models such as GPT-6-Astra stayed on the 272K default window.\n\nThis change promotes the advertised maximum for every model that declares experimental-context support, normalizes Astra to its 1,050,000-token raw limit, and refreshes context capability fields for existing models from each newer Codex bundled catalog. Account-specific metadata remains intact.\n\nValidation: Rust fmt, clippy and 508 tests; frontend lint, 165 tests and production build.