### PR TITLE
fix(codex): group visual-assistance model picker by provider

### DIFF
--- a/src/pages/Codex.test.tsx
+++ b/src/pages/Codex.test.tsx
@@ -5,7 +5,7 @@
 
 import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 let multiAgent = false
 let orphaned = false
@@ -15,6 +15,34 @@ let visualAssistance = {
   assistant_model: 'demo/vision-primary' as string | null,
   fallback_models: [] as string[],
 }
+let visionGroupingProviders = false
+
+const sharedVisionProviders = () => ({
+  'provider-a': {
+    id: 'provider-a',
+    name: 'Provider A',
+    protocol: 'openai',
+    base_url: 'https://provider-a.test',
+    has_key: true,
+    enabled: true,
+    models: [
+      { id: 'shared-vision', label: 'Shared vision', enabled: true, supports_vision: true },
+      { id: 'only-a', label: 'Only A', enabled: true, supports_vision: true },
+    ],
+  },
+  'provider-b': {
+    id: 'provider-b',
+    name: 'Provider B',
+    protocol: 'openai',
+    base_url: 'https://provider-b.test',
+    has_key: true,
+    enabled: true,
+    models: [
+      { id: 'shared-vision', label: 'Shared vision', enabled: true, supports_vision: true },
+      { id: 'only-b', label: 'Only B', enabled: true, supports_vision: true },
+    ],
+  },
+})
 const setMultiAgent = vi.fn((next: boolean) => {
   multiAgent = next
   return Promise.resolve(next)
@@ -64,7 +92,7 @@ vi.mock('@/lib/api', () => ({
     getConfig: () =>
       Promise.resolve({
         port: 4180,
-        providers: {
+        providers: visionGroupingProviders ? sharedVisionProviders() : {
           demo: {
             id: 'demo',
             name: 'Demo',
@@ -391,6 +419,41 @@ describe('visual assistance settings', () => {
         fallback_models: [],
       }),
     )
+  })
+})
+
+describe('visual assistance provider grouping', () => {
+  beforeEach(() => {
+    visionGroupingProviders = true
+    visualAssistance = {
+      enabled: false,
+      assistant_model: null,
+      fallback_models: [],
+    }
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    visionGroupingProviders = false
+    visualAssistance = {
+      enabled: false,
+      assistant_model: 'demo/vision-primary',
+      fallback_models: [],
+    }
+  })
+
+  it('groups duplicate vision model names by provider in the primary picker', async () => {
+    const user = userEvent.setup()
+    render(<CodexPage />)
+
+    await user.click(
+      await screen.findByRole('combobox', { name: /primary visual assistant/i }),
+    )
+
+    const content = screen.getByRole('listbox')
+    expect(within(content).getByText('Provider A')).toBeInTheDocument()
+    expect(within(content).getByText('Provider B')).toBeInTheDocument()
+    expect(within(content).getAllByRole('option', { name: 'Shared vision' })).toHaveLength(2)
   })
 })
 

--- a/src/pages/Codex.test.tsx
+++ b/src/pages/Codex.test.tsx
@@ -42,6 +42,17 @@ const sharedVisionProviders = () => ({
       { id: 'only-b', label: 'Only B', enabled: true, supports_vision: true },
     ],
   },
+  // Keyed and enabled but serving nothing visual: it must not reach either
+  // picker as a group header with no options under it.
+  'provider-c': {
+    id: 'provider-c',
+    name: 'Provider C',
+    protocol: 'openai',
+    base_url: 'https://provider-c.test',
+    has_key: true,
+    enabled: true,
+    models: [{ id: 'text-only', label: 'Text only', enabled: true, supports_vision: false }],
+  },
 })
 const setMultiAgent = vi.fn((next: boolean) => {
   multiAgent = next
@@ -299,8 +310,10 @@ describe('visual assistance settings', () => {
     await user.click(fallback)
     await user.click(screen.getByRole('option', { name: 'Vision fallback B' }))
     await user.click(screen.getByRole('button', { name: /add fallback/i }))
-    await user.click(screen.getByRole('button', { name: /move vision fallback b up/i }))
-    await user.click(screen.getByRole('button', { name: /remove vision fallback a/i }))
+    // The accessible name carries the provider now, so two gateways serving
+    // the same model label do not produce two identical buttons.
+    await user.click(screen.getByRole('button', { name: /move vision fallback b \(demo\) up/i }))
+    await user.click(screen.getByRole('button', { name: /remove vision fallback a \(demo\)/i }))
 
     await waitFor(() =>
       expect(setVisualAssistance).toHaveBeenLastCalledWith({
@@ -453,7 +466,48 @@ describe('visual assistance provider grouping', () => {
     const content = screen.getByRole('listbox')
     expect(within(content).getByText('Provider A')).toBeInTheDocument()
     expect(within(content).getByText('Provider B')).toBeInTheDocument()
+    expect(within(content).queryByText('Provider C')).not.toBeInTheDocument()
     expect(within(content).getAllByRole('option', { name: 'Shared vision' })).toHaveLength(2)
+  })
+
+  it('saves the provider/model slug of the duplicate the user actually picked', async () => {
+    const user = userEvent.setup()
+    render(<CodexPage />)
+
+    await user.click(
+      await screen.findByRole('combobox', { name: /primary visual assistant/i }),
+    )
+    const duplicates = within(screen.getByRole('listbox')).getAllByRole('option', {
+      name: 'Shared vision',
+    })
+    await user.click(duplicates[1])
+
+    await waitFor(() =>
+      expect(setVisualAssistance).toHaveBeenLastCalledWith({
+        enabled: false,
+        assistant_model: 'provider-b/shared-vision',
+        fallback_models: [],
+      }),
+    )
+  })
+
+  it('groups the fallback picker and drops the provider with nothing left to offer', async () => {
+    visualAssistance = {
+      enabled: true,
+      assistant_model: 'provider-a/shared-vision',
+      fallback_models: [],
+    }
+    const user = userEvent.setup()
+    render(<CodexPage />)
+
+    await user.click(await screen.findByRole('combobox', { name: /visual fallback model/i }))
+
+    const content = screen.getByRole('listbox')
+    expect(within(content).getByText('Provider A')).toBeInTheDocument()
+    expect(within(content).getByText('Provider B')).toBeInTheDocument()
+    expect(within(content).queryByText('Provider C')).not.toBeInTheDocument()
+    // Provider A's copy is the primary, so only Provider B's survives.
+    expect(within(content).getAllByRole('option', { name: 'Shared vision' })).toHaveLength(1)
   })
 })
 

--- a/src/pages/Codex.tsx
+++ b/src/pages/Codex.tsx
@@ -13,7 +13,9 @@ import { Input } from '@/components/ui/input'
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
@@ -215,24 +217,41 @@ function VisualAssistanceCard({
   const [fallbackCandidate, setFallbackCandidate] = useState(OFF_SENTINEL)
   const assistance = config?.visual_assistance ?? EMPTY_VISUAL_ASSISTANCE
 
-  const visionModels = config
+  const visionModelsByProvider = config
     ? Object.values(config.providers).flatMap((provider) =>
         provider.enabled && provider.has_key
-          ? provider.models
-              .filter(
-                (model) =>
-                  model.supports_vision &&
-                  (model.protocol ?? provider.protocol) !== 'responses',
-              )
-              .map((model) => ({ slug: `${provider.id}/${model.id}`, label: model.label ?? model.id }))
+          ? [
+              {
+                providerName: provider.name,
+                models: provider.models
+                  .filter(
+                    (model) =>
+                      model.supports_vision &&
+                      (model.protocol ?? provider.protocol) !== 'responses',
+                  )
+                  .map((model) => ({
+                    slug: `${provider.id}/${model.id}`,
+                    label: model.label ?? model.id,
+                  })),
+              },
+            ]
           : [],
       )
     : []
+  const visionModels = visionModelsByProvider.flatMap((group) => group.models)
   const supportsVision = (slug: string | null) =>
     slug !== null && visionModels.some((model) => model.slug === slug)
-  const fallbackOptions = visionModels.filter(
-    (model) => model.slug !== assistance.assistant_model && !assistance.fallback_models.includes(model.slug),
-  )
+  const fallbackOptionsByProvider = visionModelsByProvider
+    .map((group) => ({
+      providerName: group.providerName,
+      models: group.models.filter(
+        (model) =>
+          model.slug !== assistance.assistant_model &&
+          !assistance.fallback_models.includes(model.slug),
+      ),
+    }))
+    .filter((group) => group.models.length > 0)
+  const fallbackOptions = fallbackOptionsByProvider.flatMap((group) => group.models)
 
   const save = async (next: VisualAssistanceConfig) => {
     // A config can arrive from an older build or a concurrent edit. Normalize
@@ -338,10 +357,15 @@ function VisualAssistanceCard({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value={OFF_SENTINEL}>{s.codex.visualAssistancePrimaryOff}</SelectItem>
-            {visionModels.map((model) => (
-              <SelectItem key={model.slug} value={model.slug}>
-                {model.label}
-              </SelectItem>
+            {visionModelsByProvider.map(({ providerName, models }) => (
+              <SelectGroup key={providerName}>
+                <SelectLabel>{providerName}</SelectLabel>
+                {models.map((model) => (
+                  <SelectItem key={model.slug} value={model.slug}>
+                    {model.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
             ))}
           </SelectContent>
         </Select>
@@ -358,10 +382,15 @@ function VisualAssistanceCard({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value={OFF_SENTINEL}>{s.codex.visualAssistanceFallbackPlaceholder}</SelectItem>
-                {fallbackOptions.map((model) => (
-                  <SelectItem key={model.slug} value={model.slug}>
-                    {model.label}
-                  </SelectItem>
+                {fallbackOptionsByProvider.map(({ providerName, models }) => (
+                  <SelectGroup key={providerName}>
+                    <SelectLabel>{providerName}</SelectLabel>
+                    {models.map((model) => (
+                      <SelectItem key={model.slug} value={model.slug}>
+                        {model.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
                 ))}
               </SelectContent>
             </Select>

--- a/src/pages/Codex.tsx
+++ b/src/pages/Codex.tsx
@@ -217,32 +217,38 @@ function VisualAssistanceCard({
   const [fallbackCandidate, setFallbackCandidate] = useState(OFF_SENTINEL)
   const assistance = config?.visual_assistance ?? EMPTY_VISUAL_ASSISTANCE
 
-  const visionModelsByProvider = config
-    ? Object.values(config.providers).flatMap((provider) =>
-        provider.enabled && provider.has_key
-          ? [
-              {
-                providerName: provider.name,
-                models: provider.models
-                  .filter(
-                    (model) =>
-                      model.supports_vision &&
-                      (model.protocol ?? provider.protocol) !== 'responses',
-                  )
-                  .map((model) => ({
-                    slug: `${provider.id}/${model.id}`,
-                    label: model.label ?? model.id,
-                  })),
-              },
-            ]
-          : [],
-      )
-    : []
+  const visionModelsByProvider = (config ? Object.values(config.providers) : [])
+    .filter((provider) => provider.enabled && provider.has_key)
+    .map((provider) => ({
+      providerId: provider.id,
+      providerName: provider.name,
+      models: provider.models
+        .filter(
+          (model) =>
+            model.supports_vision && (model.protocol ?? provider.protocol) !== 'responses',
+        )
+        .map((model) => ({
+          slug: `${provider.id}/${model.id}`,
+          label: model.label ?? model.id,
+          providerName: provider.name,
+        })),
+    }))
+    // A provider that is enabled and keyed but serves no visual model would
+    // otherwise render a group header with nothing under it.
+    .filter((group) => group.models.length > 0)
   const visionModels = visionModelsByProvider.flatMap((group) => group.models)
+  // Two gateways can serve the same model id under the same label, so every
+  // place that names one selection outside its provider group has to say
+  // which provider it came from.
+  const qualify = (slug: string) => {
+    const option = visionModels.find((model) => model.slug === slug)
+    return option ? `${option.label} (${option.providerName})` : slug
+  }
   const supportsVision = (slug: string | null) =>
     slug !== null && visionModels.some((model) => model.slug === slug)
   const fallbackOptionsByProvider = visionModelsByProvider
     .map((group) => ({
+      providerId: group.providerId,
       providerName: group.providerName,
       models: group.models.filter(
         (model) =>
@@ -353,12 +359,16 @@ function VisualAssistanceCard({
           disabled={busy || !config}
         >
           <SelectTrigger aria-label={s.codex.visualAssistancePrimary}>
-            <SelectValue placeholder={s.codex.visualAssistancePrimary} />
+            <SelectValue placeholder={s.codex.visualAssistancePrimary}>
+              {assistantValue === OFF_SENTINEL
+                ? s.codex.visualAssistancePrimaryOff
+                : qualify(assistantValue)}
+            </SelectValue>
           </SelectTrigger>
           <SelectContent>
             <SelectItem value={OFF_SENTINEL}>{s.codex.visualAssistancePrimaryOff}</SelectItem>
-            {visionModelsByProvider.map(({ providerName, models }) => (
-              <SelectGroup key={providerName}>
+            {visionModelsByProvider.map(({ providerId, providerName, models }) => (
+              <SelectGroup key={providerId}>
                 <SelectLabel>{providerName}</SelectLabel>
                 {models.map((model) => (
                   <SelectItem key={model.slug} value={model.slug}>
@@ -382,8 +392,8 @@ function VisualAssistanceCard({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value={OFF_SENTINEL}>{s.codex.visualAssistanceFallbackPlaceholder}</SelectItem>
-                {fallbackOptionsByProvider.map(({ providerName, models }) => (
-                  <SelectGroup key={providerName}>
+                {fallbackOptionsByProvider.map(({ providerId, providerName, models }) => (
+                  <SelectGroup key={providerId}>
                     <SelectLabel>{providerName}</SelectLabel>
                     {models.map((model) => (
                       <SelectItem key={model.slug} value={model.slug}>
@@ -408,7 +418,7 @@ function VisualAssistanceCard({
           ) : (
             <ol className="space-y-1">
               {assistance.fallback_models.map((model, index) => {
-                const label = visionModels.find((option) => option.slug === model)?.label ?? model
+                const label = qualify(model)
                 return (
                   <li key={model} className="flex items-center justify-between gap-2 text-sm">
                     <span>{label}</span>


### PR DESCRIPTION
## What

Group primary and fallback visual assistant model options under provider labels so duplicate model ids from different gateways remain distinguishable. Save semantics stay on the existing provider/model slug.

## Validation

- bun run test: PASS (166 tests)
- bun run build: PASS
- bun run lint: blocked by the existing typescript-eslint / TypeScript 7.0 incompatibility in this checkout