### PR TITLE
fix(visual): forward OpenCode session to vision requests

### DIFF
--- a/src-tauri/src/proxy.rs
+++ b/src-tauri/src/proxy.rs
@@ -70,6 +70,7 @@ pub use routing::{family_of, model_protocol, ProviderFamily};
 use routing::{is_side_call, merged_opencode_provider};
 use routing::{resolve, resolve_effective, RoutePlan};
 pub use upstream::apply_provider_auth;
+pub(crate) use upstream::apply_provider_session;
 #[cfg(test)]
 use upstream::classify_status;
 use upstream::{build_upstream, needs_responses_function_tool_compat, send, send_outcome};

--- a/src-tauri/src/proxy/dispatch.rs
+++ b/src-tauri/src/proxy/dispatch.rs
@@ -144,6 +144,7 @@ pub(super) async fn dispatch_routed(
             &mut prepared_payload,
             wire,
             &destination_slug,
+            headers,
         )
         .await
         {

--- a/src-tauri/src/proxy/realtime.rs
+++ b/src-tauri/src/proxy/realtime.rs
@@ -597,6 +597,7 @@ async fn ws_session(socket: WebSocket, ctx: ProxyCtx, headers: HeaderMap) {
                     &mut payload,
                     WireApi::Responses,
                     &destination_slug,
+                    &headers,
                 )
                 .await
                 {

--- a/src-tauri/src/proxy/tests_visual.rs
+++ b/src-tauri/src/proxy/tests_visual.rs
@@ -1,5 +1,6 @@
 use super::tests_routing::demo_config;
 use super::*;
+use crate::config::{Provider, ProviderKey};
 
 #[test]
 fn finds_responses_data_and_remote_images_without_text_only_parts() {
@@ -59,6 +60,7 @@ async fn rejects_non_user_images_before_visual_provider_preparation() {
         &mut payload,
         WireApi::Responses,
         "cheap/mini",
+        &HeaderMap::new(),
     )
     .await
     .unwrap_err();
@@ -187,6 +189,7 @@ async fn native_vision_destination_bypasses_an_unconfigured_visual_chain() {
         &mut payload,
         WireApi::Responses,
         "cheap/mini",
+        &HeaderMap::new(),
     )
     .await
     .unwrap();
@@ -211,6 +214,7 @@ async fn disabled_assistance_preserves_a_text_only_request() {
         &mut payload,
         WireApi::ChatCompletions,
         "cheap/mini",
+        &HeaderMap::new(),
     )
     .await
     .unwrap();
@@ -234,6 +238,7 @@ async fn disabled_assistance_preserves_images_for_an_uncatalogued_routed_model()
         &mut payload,
         WireApi::Responses,
         "cheap/not-in-models",
+        &HeaderMap::new(),
     )
     .await
     .unwrap();
@@ -258,12 +263,119 @@ async fn exhausted_visual_chain_returns_before_the_text_only_payload_is_built() 
         &mut payload,
         WireApi::Responses,
         "cheap/mini",
+        &HeaderMap::new(),
     )
     .await
     .unwrap_err();
 
     assert!(error.to_string().contains("no primary model configured"));
     assert_eq!(payload, original);
+}
+
+#[derive(Clone)]
+struct VisualSessionProbe {
+    seen: Arc<Mutex<Vec<String>>>,
+}
+
+async fn visual_session_probe_handler(
+    axum::extract::Extension(probe): axum::extract::Extension<VisualSessionProbe>,
+    headers: HeaderMap,
+) -> axum::Json<Value> {
+    if let Some(value) = headers.get("x-opencode-session") {
+        probe
+            .seen
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .push(value.to_str().unwrap_or_default().to_string());
+    }
+    axum::Json(json!({
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": "{\"summary\":\"ok\",\"ocr\":\"\",\"layout\":\"\",\"semantics\":\"\",\"uncertainty\":\"\"}"
+            }
+        }]
+    }))
+}
+
+#[tokio::test]
+async fn visual_assistance_forwards_the_opencode_session_header() {
+    use axum::routing::post;
+
+    let probe = VisualSessionProbe {
+        seen: Arc::new(Mutex::new(Vec::new())),
+    };
+    let app = axum::Router::new()
+        .route("/v1/chat/completions", post(visual_session_probe_handler))
+        .layer(axum::Extension(probe.clone()));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let mut cfg = demo_config(None);
+    let provider = Provider {
+        id: crate::providers::OPENCODE_GO_PROVIDER_ID.into(),
+        name: "OpenCode Go".into(),
+        protocol: crate::config::ProviderProtocol::OpenAI,
+        base_url: format!("http://{address}/v1"),
+        api_key: None,
+        keys: vec![ProviderKey {
+            id: "primary".into(),
+            name: "Primary".into(),
+            enabled: true,
+            api_key: Some("sk-test".into()),
+            has_key: true,
+        }],
+        rotation_enabled: false,
+        has_key: true,
+        context_window: None,
+        user_agent: None,
+        prompt_cache: None,
+        models: vec![crate::config::ProviderModel {
+            id: "mimo-v2.5".into(),
+            label: None,
+            context_window: None,
+            protocol: Some(crate::config::ProviderProtocol::OpenAI),
+            fast_mode: false,
+            enabled: true,
+            supports_vision: true,
+        }],
+        enabled: true,
+    };
+    cfg.providers.insert(provider.id.clone(), provider);
+    cfg.visual_assistance.enabled = true;
+    cfg.visual_assistance.assistant_model = Some("opencode-go/mimo-v2.5".into());
+
+    let mut payload = json!({
+        "input": [{"role": "user", "content": [
+            {"type": "input_text", "text": "describe"},
+            {"type": "input_image", "image_url": "data:image/png;base64,aGVsbG8="}
+        ]}]
+    });
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "x-opencode-session",
+        "visual-session".parse().expect("header value"),
+    );
+
+    prepare_visual_assistance(
+        &reqwest::Client::new(),
+        &cfg,
+        &mut payload,
+        WireApi::Responses,
+        "cheap/mini",
+        &headers,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(
+        *probe.seen.lock().unwrap_or_else(|error| error.into_inner()),
+        vec!["visual-session"]
+    );
+    assert!(image_parts_in_payload(&payload, WireApi::Responses).is_empty());
 }
 
 #[tokio::test]

--- a/src-tauri/src/proxy/upstream.rs
+++ b/src-tauri/src/proxy/upstream.rs
@@ -64,6 +64,31 @@ pub fn apply_provider_auth(
     }
 }
 
+/// Forward the caller's OpenCode session to Console Go.
+///
+/// Console Go rejects otherwise valid requests without this header. Applying it
+/// through one helper keeps visual side calls aligned with routed turns.
+pub(crate) fn apply_provider_session(
+    request: reqwest::RequestBuilder,
+    provider: &Provider,
+    headers: Option<&HeaderMap>,
+) -> reqwest::RequestBuilder {
+    if provider.id != crate::providers::OPENCODE_GO_PROVIDER_ID {
+        return request;
+    }
+    let Some(session) = headers.and_then(|headers| {
+        // An empty value fails upstream the same way a missing one does, so
+        // skip it and let the next candidate win instead of forwarding a
+        // header that only makes the rejection harder to read.
+        SESSION_HEADER_CANDIDATES
+            .iter()
+            .find_map(|name| headers.get(*name).filter(|value| !value.is_empty()))
+    }) else {
+        return request;
+    };
+    request.header("x-opencode-session", session.clone())
+}
+
 /// Send a prepared JSON body upstream and return its raw response.
 ///
 /// A non-2xx answer is returned, not turned into an error: the caller forwards
@@ -245,20 +270,7 @@ async fn send_with_key(
         request = request.header("user-agent", user_agent);
     }
     request = apply_provider_auth(request, provider, body.get("model").and_then(Value::as_str));
-    // Console Go requires the client session id as x-opencode-session; other
-    // upstreams reject unknown headers, so this stays provider-scoped.
-    if provider.id == crate::providers::OPENCODE_GO_PROVIDER_ID {
-        if let Some(session) = extra_headers.and_then(|headers| {
-            // An empty value fails upstream the same way a missing one does, so
-            // skip it and let the next candidate win instead of forwarding a
-            // header that only makes the rejection harder to read.
-            SESSION_HEADER_CANDIDATES
-                .iter()
-                .find_map(|name| headers.get(*name).filter(|value| !value.is_empty()))
-        }) {
-            request = request.header("x-opencode-session", session.clone());
-        }
-    }
+    request = apply_provider_session(request, provider, extra_headers);
     request.send().await.map_err(|e| {
         let message = upstream_unreachable_error(&url, &e, &format!("provider '{}'", provider.id))
             .to_string();

--- a/src-tauri/src/proxy/visuals.rs
+++ b/src-tauri/src/proxy/visuals.rs
@@ -208,6 +208,7 @@ pub(super) async fn prepare_visual_assistance(
     payload: &mut Value,
     wire: WireApi,
     destination_slug: &str,
+    headers: &HeaderMap,
 ) -> anyhow::Result<Option<VisualAssistanceMetadata>> {
     let images = image_parts_in_payload(payload, wire);
     if images.is_empty() || !config.visual_assistance.enabled {
@@ -224,7 +225,8 @@ pub(super) async fn prepare_visual_assistance(
     let mut attempts = Vec::new();
     for image in &images {
         let image_started = std::time::Instant::now();
-        let outcome = visual::analyze_with_fallbacks(client, config, &image.image, None).await?;
+        let outcome =
+            visual::analyze_with_fallbacks(client, config, &image.image, None, headers).await?;
         attempts.extend(outcome.attempts.iter().map(visual_attempt_provenance));
         let block = visual::evidence_block(&outcome.evidence, &outcome.model);
         match evidence_by_message.last_mut() {

--- a/src-tauri/src/visual.rs
+++ b/src-tauri/src/visual.rs
@@ -5,6 +5,7 @@
 
 use crate::config::{AppConfig, Provider, ProviderKey, ProviderModel, ProviderProtocol};
 use anyhow::{anyhow, bail, Context};
+use axum::http::HeaderMap;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
@@ -150,6 +151,7 @@ pub async fn analyze_with_fallbacks(
     config: &AppConfig,
     image: &ImagePart,
     instruction: Option<&str>,
+    headers: &HeaderMap,
 ) -> anyhow::Result<VisionOutcome> {
     let candidates = configured_candidates(config)?;
     let image = prepare_image(client, image).await?;
@@ -171,7 +173,7 @@ pub async fn analyze_with_fallbacks(
     let mut attempts = Vec::new();
     for candidate in candidates {
         let started = Instant::now();
-        match request_evidence(client, &candidate, &image, instruction).await {
+        match request_evidence(client, &candidate, &image, instruction, headers).await {
             Ok(evidence) => {
                 let model = candidate.slug.clone();
                 attempts.push(VisionAttempt {
@@ -605,10 +607,15 @@ async fn request_evidence(
     candidate: &Candidate<'_>,
     image: &PreparedImage,
     instruction: Option<&str>,
+    headers: &HeaderMap,
 ) -> Result<Value, RequestFailure> {
     match candidate.protocol {
-        ProviderProtocol::OpenAI => request_openai(client, candidate, image, instruction).await,
-        ProviderProtocol::Anthropic => request_anthropic(client, candidate, image, instruction).await,
+        ProviderProtocol::OpenAI => {
+            request_openai(client, candidate, image, instruction, headers).await
+        }
+        ProviderProtocol::Anthropic => {
+            request_anthropic(client, candidate, image, instruction, headers).await
+        }
         ProviderProtocol::Responses => Err(RequestFailure::local(
             "Responses protocol is unsupported for visual assistants in this MVP; configure an OpenAI Chat Completions or Anthropic Messages vision model",
         )),
@@ -620,6 +627,7 @@ async fn request_openai(
     candidate: &Candidate<'_>,
     image: &PreparedImage,
     instruction: Option<&str>,
+    headers: &HeaderMap,
 ) -> Result<Value, RequestFailure> {
     let endpoint = format!(
         "{}/chat/completions",
@@ -637,6 +645,7 @@ async fn request_openai(
         &provider,
         Some(&candidate.model.id),
     );
+    request = crate::proxy::apply_provider_session(request, &provider, Some(headers));
     if let Some(user_agent) = &candidate.provider.user_agent {
         request = request.header("user-agent", user_agent);
     }
@@ -673,6 +682,7 @@ async fn request_anthropic(
     candidate: &Candidate<'_>,
     image: &PreparedImage,
     instruction: Option<&str>,
+    headers: &HeaderMap,
 ) -> Result<Value, RequestFailure> {
     let endpoint = format!(
         "{}/messages",
@@ -694,7 +704,7 @@ async fn request_anthropic(
         }],
         "tool_choice": {"type": "tool", "name": "submit_visual_evidence"}
     });
-    let response = client
+    let request = client
         .post(endpoint)
         .header(
             "x-api-key",
@@ -705,10 +715,9 @@ async fn request_anthropic(
                 .expect("validated before request"),
         )
         .header("anthropic-version", "2023-06-01")
-        .json(&body)
-        .send()
-        .await
-        .map_err(request_error)?;
+        .json(&body);
+    let request = crate::proxy::apply_provider_session(request, candidate.provider, Some(headers));
+    let response = request.send().await.map_err(request_error)?;
     response_json(response).await.and_then(|payload| {
         let evidence = payload
             .get("content")


### PR DESCRIPTION
## Summary

- forward the caller's OpenCode session header to visual-assistance model calls
- reuse one provider-session helper for routed and visual upstream requests
- add a regression test covering the visual request path

## Root cause

OpenCode Go requires `x-opencode-session` on every request. LoomRouter 0.2.17 forwarded that header for routed turns, but omitted it from visual-assistance side calls. The provider returned `HTTP 400 MissingSessionID`, which LoomRouter surfaced as the reported `502 Bad Gateway`.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` (489 unit, 21 e2e, 1 stream, 2 live smoke)
- `bun run lint`
- `bun run test` (168 tests)
- `bun run build`
- end-to-end image request through the patched 0.2.17 binary returned HTTP 200 and completed visual analysis